### PR TITLE
Fix save_history limiting GIF animation to ~2 frames (#8)

### DIFF
--- a/pytopo3d/core/optimizer.py
+++ b/pytopo3d/core/optimizer.py
@@ -149,7 +149,11 @@ def top3d(
     # ─────────────────────── main loop
     loop, change, c_prev = 0, 1.0, np.inf
     if save_history:
-        history_frequency = max(history_frequency, 500)
+        # Cap the interval at 500 so even long runs save frames, while still honouring
+        # a smaller requested frequency. `max(...)` here forced a *minimum* interval of
+        # 500, so any run converging in <500 iterations saved only the first and last
+        # frame (issue #8: "GIF animation limited to 2 frames").
+        history_frequency = min(history_frequency, 500)
         if gpu:
             history["density_history"].append(cp.asnumpy(xPhys_gpu))
         else:

--- a/tests/test_cpu_smoke.py
+++ b/tests/test_cpu_smoke.py
@@ -88,3 +88,15 @@ def test_determinism(small_case):
     a = top3d(**small_case)
     b = top3d(**small_case)
     assert np.array_equal(a, b)
+
+
+def test_save_history_records_multiple_frames():
+    """Regression for issue #8: a short run with save_history must record more than just
+    the first and last frame. The old `max(history_frequency, 500)` floor collapsed any
+    run converging in under 500 iterations to ~2 GIF frames."""
+    _, history = top3d(
+        nelx=12, nely=6, nelz=6, volfrac=0.3, penal=3.0, rmin=1.5, disp_thres=0.5,
+        tolx=0.01, maxloop=40, save_history=True, history_frequency=10, use_gpu=False,
+    )
+    frames = len(history["density_history"])
+    assert frames > 2, f"expected several frames, got {frames} (issue #8 regression)"


### PR DESCRIPTION
## Summary

Fixes #8: when `save_history=True`, the generated GIF was limited to ~2 frames.

## Cause

`top3d` clamped the history sampling interval with `history_frequency = max(history_frequency, 500)`, which forces a **minimum** interval of 500 iterations. Any run that converges in fewer than 500 iterations therefore recorded only the initial and final frames.

## Fix

Change `max` to `min`, so 500 becomes an **upper bound** on the interval (long runs still get frames) while a smaller requested `history_frequency` is honoured.

The reporter's second suggestion (loop condition `change <= tolx` → `>= tolx`) was **not** applied: `change` decreases from 1.0 toward `tolx`, so `>=` would save on nearly every iteration (defeating `history_frequency`) and could even miss the final converged frame.

## Verification

On a 12×6×6 run with `maxloop=60`, `history_frequency=10`, recorded frames went from **1 → 7** (iterations `[0, 10, 20, 30, 40, 50, 60]`). Added a regression test `test_save_history_records_multiple_frames`.

Credit to @matlab-user for the clear diagnosis and proposed fix.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
