### PR TITLE
Bump version to 0.1.1 and set author email

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ Below is the roadmap for future releases of PyTopo3D:
 
 ### Version 0.4.0 (Pre-release Stabilization)
 - **API Stabilization**: Finalize API design for 1.0 release
-- **Comprehensive Testing**: Extensive test suite for all components (probably with `pytest`)
+- **Comprehensive Testing**: Extensive test suite for all components (probably with `pytest`). *An initial `pytest` suite (CPU core + packaging guards) and GitHub Actions CI landed early, in 0.1.1.*
 - **Performance Benchmarking**: Establish baseline performance metrics
 
 ### Version 1.0.0 (Stable Release)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytopo3d"
-version = "0.1.0"
+version = "0.1.1"
 description = "3D SIMP Topology Optimization Framework for Python"
 readme = "README.md"
 authors = [
-    {name = "Jihoon Kim", email = "jihoonkim888@example.com"},  # Replace with actual email
-    {name = "Namwoo Kang", email = "example@example.com"},      # Replace with actual email
+    {name = "Jihoon Kim", email = "jihoon.kim@kaist.ac.kr"},
+    {name = "Namwoo Kang", email = "nwkang@kaist.ac.kr"},
 ]
 license = {text = "MIT"}
 classifiers = [


### PR DESCRIPTION
## Summary

Prepares the **0.1.1** patch release.

- Bumps `version` `0.1.0` → `0.1.1`. Collects the bug fixes merged since 0.1.0 (#6 broken packaging, #7 CPU-only crash, #8 GIF frames) — bug fixes only, no API changes, so a patch bump per semver.
- The original 0.1.0 on PyPI shipped an empty package, so PyPI requires a new version number to re-publish; 0.1.1 is effectively the first working release.
- Sets both author emails to real KAIST addresses (`jihoon.kim@kaist.ac.kr`, `nwkang@kaist.ac.kr`); they were placeholders.

## Verification

A built wheel reports `Version: 0.1.1` and `Author-email: Jihoon Kim <jihoon.kim@kaist.ac.kr>, Namwoo Kang <nwkang@kaist.ac.kr>`, with the `gpu` extra intact.

## Note

Merging this only updates the version metadata — it does not publish to PyPI. Uploading 0.1.1 is a separate step (`python -m build` + `twine upload`, or a release workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
