### PR TITLE
Make the [gpu] extra self-contained (cupy-cuda12x[ctk])

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ pip install pytopo3d[gpu]
 pip install -e ".[gpu]"
 ```
 
-This will install the required `cupy` dependency. Make sure to use the appropriate CUDA version that matches your system (e.g., `cupy-cuda11x` for CUDA 11.x, `cupy-cuda12x` for CUDA 12.x).
+This installs CuPy with the `[ctk]` extra, which bundles the CUDA toolkit (libraries and headers) as wheels so GPU acceleration works without a separate system CUDA installation. The `[gpu]` extra targets CUDA 12.x; if you are on CUDA 11.x, install `cupy-cuda11x[ctk]` manually instead.
 
 #### Enabling GPU Acceleration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytopo3d"
-version = "0.1.1"
+version = "0.1.2"
 description = "3D SIMP Topology Optimization Framework for Python"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,10 @@ dev = [
     "jupyterlab",
 ]
 gpu = [
-    "cupy-cuda12x",  # Replace with appropriate CUDA version as needed
+    # The [ctk] extra bundles the CUDA toolkit (libraries + headers) as wheels, so GPU
+    # acceleration works without a separate system CUDA install. For CUDA 11.x, use
+    # cupy-cuda11x[ctk] instead.
+    "cupy-cuda12x[ctk]",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

Makes the `[gpu]` install extra self-contained by switching it from bare `cupy-cuda12x` to `cupy-cuda12x[ctk]`.

## Why

`pip install pytopo3d[gpu]` previously pulled bare `cupy-cuda12x`, which relies on a **system CUDA toolkit** being present. On a clean machine without one, GPU acceleration fails at runtime — missing `libnvJitLink` and the CUDA headers CuPy needs to JIT-compile its kernels (observed directly on the test cluster). The `[ctk]` extra bundles the CUDA toolkit (libraries **and** headers) as pip wheels, so the GPU path works without a separate system CUDA install.

**Trade-off:** a larger download. That is acceptable for an opt-in GPU extra. The README documents the CUDA-11 alternative (`cupy-cuda11x[ctk]`).

## Verification

A built wheel's metadata now declares `Requires-Dist: cupy-cuda12x[ctk]; extra == "gpu"`. The packaging guard (`tests/test_packaging.py`) still passes (the dep still contains `cupy`).

## Note

This is a dependency change to the published package, so it reaches users only on the next PyPI release (a `0.1.2` version bump + release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
