### PR TITLE
Fix STL x/y axis convention and document coordinate system (0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-06-13
+
+### Fixed (breaking)
+
+- **STL import and export now use a consistent `x`/`y` axis convention.** `trimesh`
+  voxel grids come in CAD axis order `(x, y, z)`, but they were stored directly as the
+  solver's `(nely, nelx, nelz)` array, so an STL's x-axis became the domain's y-axis.
+  For any non-cube STL this placed the default supports/loads and JSON obstacles on the
+  wrong faces, and made the matplotlib view disagree with the exported STL. STL import
+  (`stl_to_design_space`) and STL export (`voxel_to_stl`, `voxel_to_stl_tpms`) now swap
+  the first two axes so an STL's x-axis maps to the domain's x-axis (`nelx`), matching
+  the `nelx`/`nely` arguments, JSON obstacle `center = [x, y, z]`, and `force_field`
+  everywhere else in the library.
+
+  **Impact:** any workflow that imports or exports STL is affected. The orientation now
+  follows the `x = nelx` convention, so a result is identical to 0.1.x only for parts
+  that are symmetric under an `x` <-> `y` swap (a cube *bounding box* is not enough — an
+  asymmetric part inside it still transposes). Non-STL (pure-array) usage — passing
+  `nelx`/`nely`/`nelz` and NumPy masks directly, with no STL — is unchanged: the
+  numerical core and the golden-master result are byte-identical.
+
+  **Migration:** to reproduce pre-0.2.0 results, pin `pytopo3d==0.1.2`. As a transitional
+  aid, 0.2.0 emits a one-time notice the first time an STL is imported or exported; it is
+  removed in 0.3.0.
+
+### Changed
+
+- Corrected the misleading default-load comment in `build_force_vector`: the default
+  load is a downward (`-z`) force along the line `x = nelx, z = 0` spanning all `y`, not
+  "`y = 0`".
+
+### Removed
+
+- Removed the unused `calculate_boundary_positions` helper — dead code that still carried
+  the old MATLAB `y`-flip visualization convention.
+
+### Added
+
+- A "Coordinate system and axis conventions" section in the README.
+- Documentation of the default load direction (`-z`, z-up), how it differs from MATLAB
+  `top3d`'s `-y`, and a `force_field` recipe for reproducing the canonical `top3d` cantilever.
+- A one-time runtime notice on first STL import/export about the axis-convention change
+  (transitional; removed in 0.3.0).
+- `tests/test_stl_orientation.py`, which locks the STL import/export axis convention.
+
+## [0.1.2]
+
+- Last release before the coordinate-convention fix. STL design spaces are loaded with
+  their `x` and `y` axes transposed relative to the rest of the API.

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ you, so an STL's x-axis maps to the domain's `x` (`nelx`).
 > **Changed in 0.2.0:** STL import/export now map an STL's x-axis to the domain's x-axis.
 > Before 0.2.0 they were transposed, so **any** STL import/export workflow now produces
 > different results (identical to 0.1.x only for `x`<->`y`-symmetric parts); non-STL usage
-> is unchanged. To reproduce pre-0.2.0 results, pin `pytopo3d==0.1.2`. 0.2.0 prints a
-> one-time notice on first STL use. See the [CHANGELOG](CHANGELOG.md).
+> is unchanged. To reproduce pre-0.2.0 results, pin `pytopo3d==0.1.2`. 0.2.0 emits a
+> one-time warning on first STL use. See the [CHANGELOG](CHANGELOG.md).
 
 #### Default load direction vs MATLAB `top3d`
 
@@ -131,9 +131,9 @@ related by a `y` <-> `z` swap (PyTopo3D bends in the `x-z` plane, `top3d` bends 
 PyTopo3D keeps `-z` on purpose, since z-up is the CAD/STL convention and stays internally
 consistent with the rest of the framework.
 
-To reproduce the canonical `top3d` cantilever load case (a tip load in `-y`, bending in the
-`x-y` plane), pass a `force_field`. The default supports already match `top3d`, so only the
-load differs:
+To set up a `top3d`-style cantilever (a downward `-y` load at the free-end tip, bending in
+the `x-y` plane), pass a `force_field`. The default supports already match `top3d`, so only
+the load differs:
 
 ```python
 import numpy as np
@@ -141,9 +141,15 @@ from pytopo3d.core.optimizer import top3d
 
 nelx, nely, nelz = 60, 20, 10
 force_field = np.zeros((nely, nelx, nelz, 3))
-force_field[0, nelx - 1, :, 1] = -1.0  # -y load on the far-x, y=0 tip edge (top3d-style)
+force_field[0, nelx - 1, :, 1] = -1.0  # -y load on the far-x tip elements (y=0 row, all z)
 result = top3d(nelx, nely, nelz, 0.3, 3.0, 1.5, 0.5, force_field=force_field)
 ```
+
+Note: `force_field` is **element**-based — `build_force_vector` spreads each element's force
+over its 8 corner nodes — so this loads the tip *elements* rather than the exact nodal edge
+that MATLAB `top3d` uses (the total magnitude also differs). It reproduces the load direction
+and bending plane, which is what matters for orientation comparison, not `top3d`'s exact
+nodal load.
 
 ### Command-line Interface
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,49 @@ The main optimization parameters are:
 - `tolx`: Convergence tolerance on design change (default: 0.01)
 - `maxloop`: Maximum number of iterations (default: 2000)
 
+### Coordinate System and Axis Conventions
+
+PyTopo3D uses a right-handed Cartesian `(x, y, z)` convention with `z` as the vertical axis.
+`x`, `y`, `z` mean the same thing across the whole public surface:
+
+- `nelx`, `nely`, `nelz` count elements along x, y, z.
+- JSON obstacle `center`/`size` and `force_field` components `[Fx, Fy, Fz]` are in `(x, y, z)` order.
+- The default load is a downward `-z` force along the far-x bottom edge (`x = nelx`, `z = 0`, spanning all `y`); the default support fixes the entire `x = 0` face.
+
+Internally, density and mask arrays are stored as `(nely, nelx, nelz)` — the y-axis comes
+first — a layout inherited from the MATLAB `top3d` reference. So when you build a mask by
+hand, index it as `mask[y, x, z]`. STL import and export transpose the first two axes for
+you, so an STL's x-axis maps to the domain's `x` (`nelx`).
+
+> **Changed in 0.2.0:** STL import/export now map an STL's x-axis to the domain's x-axis.
+> Before 0.2.0 they were transposed, so **any** STL import/export workflow now produces
+> different results (identical to 0.1.x only for `x`<->`y`-symmetric parts); non-STL usage
+> is unchanged. To reproduce pre-0.2.0 results, pin `pytopo3d==0.1.2`. 0.2.0 prints a
+> one-time notice on first STL use. See the [CHANGELOG](CHANGELOG.md).
+
+#### Default load direction vs MATLAB `top3d`
+
+The default load is `-z` (z-up), consistent with the CAD/STL convention used everywhere else
+in PyTopo3D. The MATLAB `top3d` reference instead loads in `-y`: its vertical axis is `y`,
+inherited from the 2D `top88`/`top99` lineage. The two default cantilevers are therefore
+related by a `y` <-> `z` swap (PyTopo3D bends in the `x-z` plane, `top3d` bends in `x-y`).
+PyTopo3D keeps `-z` on purpose, since z-up is the CAD/STL convention and stays internally
+consistent with the rest of the framework.
+
+To reproduce the canonical `top3d` cantilever load case (a tip load in `-y`, bending in the
+`x-y` plane), pass a `force_field`. The default supports already match `top3d`, so only the
+load differs:
+
+```python
+import numpy as np
+from pytopo3d.core.optimizer import top3d
+
+nelx, nely, nelz = 60, 20, 10
+force_field = np.zeros((nely, nelx, nelz, 3))
+force_field[0, nelx - 1, :, 1] = -1.0  # -y load on the far-x, y=0 tip edge (top3d-style)
+result = top3d(nelx, nely, nelz, 0.3, 3.0, 1.5, 0.5, force_field=force_field)
+```
+
 ### Command-line Interface
 
 To run a basic optimization:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytopo3d"
-version = "0.1.2"
+version = "0.2.0"
 description = "3D SIMP Topology Optimization Framework for Python"
 readme = "README.md"
 authors = [

--- a/pytopo3d/utils/assembly.py
+++ b/pytopo3d/utils/assembly.py
@@ -45,13 +45,13 @@ def build_force_vector(
     F = np.zeros(ndof)
 
     if force_field is None:
-        # Default implementation - forces on nodes at x=nelx, y=0 in -z direction
-        # Nodes on the line x = nelx, y = 0
+        # Default load: a unit downward (-z) force on every node of the far x face at
+        # z=0, i.e. the line x=nelx, z=0 spanning all y (il=nelx, jl=all y, kl=0).
         il, jl, kl = np.meshgrid(
             [nelx],
             np.arange(nely + 1),
             [0],
-            indexing="ij",  # Only y=0
+            indexing="ij",
         )
         # Calculate 0-based global node indices using Fortran order
         # nid = iy + ix * (nely + 1) + iz * (nelx + 1) * (nely + 1)

--- a/pytopo3d/utils/axis_convention.py
+++ b/pytopo3d/utils/axis_convention.py
@@ -21,4 +21,6 @@ def warn_stl_axis_change_once() -> None:
     global _WARNED
     if not _WARNED:
         _WARNED = True
-        warnings.warn(_MESSAGE, UserWarning, stacklevel=2)
+        # stacklevel=3: warn -> warn_stl_axis_change_once -> public STL fn -> user code,
+        # so 3 points the warning at the caller of stl_to_design_space / voxel_to_stl.
+        warnings.warn(_MESSAGE, UserWarning, stacklevel=3)

--- a/pytopo3d/utils/axis_convention.py
+++ b/pytopo3d/utils/axis_convention.py
@@ -1,0 +1,24 @@
+"""One-time runtime notice for the 0.2.0 STL axis-convention change.
+
+Transitional: emitted once per session the first time an STL is imported or exported,
+so users upgrading from 0.1.x notice that STL results now differ. Remove in 0.3.0.
+"""
+
+import warnings
+
+_WARNED = False
+
+_MESSAGE = (
+    "PyTopo3D 0.2.0 changed the STL axis convention: an STL's x-axis now maps to the "
+    "domain's x-axis (nelx), so STL import/export results differ from 0.1.x. Non-STL "
+    "(pure-array) usage is unchanged. Pin pytopo3d==0.1.2 to reproduce pre-0.2.0 "
+    "results. See CHANGELOG.md. (Shown once; removed in 0.3.0.)"
+)
+
+
+def warn_stl_axis_change_once() -> None:
+    """Emit the STL axis-convention change notice at most once per session."""
+    global _WARNED
+    if not _WARNED:
+        _WARNED = True
+        warnings.warn(_MESSAGE, UserWarning, stacklevel=2)

--- a/pytopo3d/utils/boundary.py
+++ b/pytopo3d/utils/boundary.py
@@ -9,41 +9,6 @@ from typing import Tuple
 import numpy as np
 
 
-def calculate_boundary_positions(
-    nelx: int, nely: int, nelz: int
-) -> Tuple[
-    Tuple[np.ndarray, np.ndarray, np.ndarray], Tuple[np.ndarray, np.ndarray, np.ndarray]
-]:
-    """
-    Calculate the positions of loads and constraints for visualization.
-
-    Parameters
-    ----------
-    nelx, nely, nelz : int
-        Number of elements in x, y, z directions.
-
-    Returns
-    -------
-    Tuple[Tuple[np.ndarray, np.ndarray, np.ndarray], Tuple[np.ndarray, np.ndarray, np.ndarray]]
-        (load_positions, constraint_positions), where each position is a tuple of (x, y, z) arrays.
-    """
-    # Calculate load positions
-    il, jl, kl = np.meshgrid([nelx], [0], np.arange(nelz + 1), indexing="ij")
-    load_x = il.ravel()
-    load_y = nely - jl.ravel()  # Converted to visualization coordinates
-    load_z = kl.ravel()
-
-    # Calculate constraint positions
-    iif, jf, kf = np.meshgrid(
-        [0], np.arange(nely + 1), np.arange(nelz + 1), indexing="ij"
-    )
-    constraint_x = iif.ravel()
-    constraint_y = nely - jf.ravel()  # Converted to visualization coordinates
-    constraint_z = kf.ravel()
-
-    return (load_x, load_y, load_z), (constraint_x, constraint_y, constraint_z)
-
-
 def create_boundary_arrays(
     nelx: int, nely: int, nelz: int
 ) -> Tuple[np.ndarray, np.ndarray]:

--- a/pytopo3d/utils/export.py
+++ b/pytopo3d/utils/export.py
@@ -10,6 +10,8 @@ from scipy.interpolate import RegularGridInterpolator
 from scipy.ndimage import distance_transform_edt
 from skimage import measure
 
+from pytopo3d.utils.axis_convention import warn_stl_axis_change_once
+
 
 def voxel_to_stl(
     input_file: Union[str, np.ndarray],
@@ -49,6 +51,8 @@ def voxel_to_stl(
     Union[str, trimesh.Trimesh]
         The path to the saved STL file if output_file is provided, otherwise the generated trimesh.Trimesh object.
     """
+    warn_stl_axis_change_once()
+
     # 1. Load the voxel data from the .npy file or use the provided array
     if isinstance(input_file, str):
         voxel_data: np.ndarray = np.load(input_file)
@@ -56,6 +60,12 @@ def voxel_to_stl(
         voxel_data = input_file
     else:
         raise TypeError("input_file must be a string path or a NumPy array.")
+
+    # PyTopo3D stores densities as (nely, nelx, nelz). Swap the first two axes so the
+    # exported mesh's x corresponds to the domain's x (nelx), mirroring the import
+    # convention in import_design_space.stl_to_design_space. Without this an STL that is
+    # imported and then exported comes back with its x and y transposed.
+    voxel_data = voxel_data.swapaxes(0, 1)
 
     # 2. Pad the voxel data with zeros to ensure a closed mesh
     if padding > 0:
@@ -197,6 +207,8 @@ def voxel_to_stl_tpms(
     Returns:
         Union[str, trimesh.Trimesh]: The path to the saved STL file if output_stl_path is provided, otherwise the generated trimesh.Trimesh object.
     """
+    warn_stl_axis_change_once()
+
     logging.info("Starting mat2stl conversion with shell from density mask...")
     t_start = time.time()
 
@@ -209,6 +221,9 @@ def voxel_to_stl_tpms(
         V = input_npy_path
     else:
         raise TypeError("input_npy_path must be a string path or a NumPy array.")
+    # Match voxel_to_stl / stl_to_design_space: densities are (nely, nelx, nelz);
+    # swap the first two axes so the TPMS mesh's x maps to the domain's x (nelx).
+    V = V.swapaxes(0, 1)
     logging.debug(f"   Data shape: {V.shape}   (took {time.time() - t1:.2f}s)")
 
     # ── 2. Define regular & evaluation grids ─────────────────────────────────

--- a/pytopo3d/utils/import_design_space.py
+++ b/pytopo3d/utils/import_design_space.py
@@ -10,6 +10,8 @@ import os
 import numpy as np
 import trimesh
 
+from pytopo3d.utils.axis_convention import warn_stl_axis_change_once
+
 
 def import_stl(stl_file: str) -> trimesh.Trimesh:
     """
@@ -98,11 +100,20 @@ def stl_to_design_space(
     np.ndarray
         Boolean array where True values represent the design space.
     """
+    warn_stl_axis_change_once()
+
     # Import the STL file
     mesh = import_stl(stl_file)
 
     # Voxelize the mesh with specified pitch
     voxels = voxelize_mesh(mesh, pitch)
+
+    # trimesh returns the voxel grid in CAD axis order (x, y, z), but the solver
+    # and every mask in PyTopo3D use (nely, nelx, nelz) == (y, x, z). Swap the
+    # first two axes so an STL's x maps to the domain's x (not its y). Without
+    # this the design space, default supports/loads, and obstacles all land on
+    # the wrong faces for any non-cube part.
+    voxels = voxels.swapaxes(0, 1)
 
     # Invert if requested
     if invert:

--- a/tests/test_stl_orientation.py
+++ b/tests/test_stl_orientation.py
@@ -13,7 +13,7 @@ import pytest
 trimesh = pytest.importorskip("trimesh")
 pytest.importorskip("skimage")
 
-from pytopo3d.utils.export import voxel_to_stl
+from pytopo3d.utils.export import voxel_to_stl, voxel_to_stl_tpms
 from pytopo3d.utils.import_design_space import stl_to_design_space
 
 # An intentionally asymmetric box so every axis has a distinct length:
@@ -44,8 +44,35 @@ def test_stl_export_maps_nelx_to_x():
     assert ex > ez > ey
 
 
+def test_export_places_content_on_correct_axis():
+    """Content-level check: a cube-shaped array carries no shape information, so only a
+    correct axis mapping puts a bar that runs along nelx onto the mesh's x-axis. Guards
+    against a 'right shape, wrong content' regression (e.g. reshape instead of swapaxes)
+    that the solid-box tests above cannot catch."""
+    block = np.zeros((6, 6, 6), dtype=float)
+    block[0:2, :, 0:2] = 1.0  # solid bar along the nelx axis, at the y=0,z=0 corner
+    mesh = voxel_to_stl(block, output_file=None, smooth_mesh=False, fix_mesh=False)
+    ex, ey, ez = mesh.extents
+    assert ex > 2 * ey and ex > 2 * ez
+
+
+def test_tpms_export_places_content_on_correct_axis():
+    """voxel_to_stl_tpms applies the same axis swap; a bar along nelx must export x-long.
+    Cube-shaped array so only the axis mapping (not the shape) can satisfy this."""
+    block = np.zeros((6, 6, 6), dtype=float)
+    block[0:2, :, 0:2] = 1.0
+    mesh = voxel_to_stl_tpms(block, output_stl_path=None, res_factor=2, plot_mapping=False)
+    ex, ey, ez = mesh.extents
+    assert ex > ey and ex > ez
+
+
 def test_stl_round_trip_preserves_orientation(tmp_path):
-    """Import then export must return a mesh with the same axis-aspect order (no net flip)."""
+    """Import then export must return a mesh with the same axis-aspect order (no net flip).
+
+    Note: this only checks import/export *consistency*. It cannot catch a regression that
+    drops the swap in BOTH directions (those cancel out, leaving the round trip unchanged) --
+    the standalone import/export tests above cover that case.
+    """
     stl = tmp_path / "block.stl"
     trimesh.creation.box(extents=BOX_EXTENTS).export(stl)
 

--- a/tests/test_stl_orientation.py
+++ b/tests/test_stl_orientation.py
@@ -63,14 +63,18 @@ def test_axis_change_notice_fires_once(tmp_path):
 
     import pytopo3d.utils.axis_convention as ac
 
-    ac._WARNED = False  # reset session-once flag for a deterministic check
     stl = tmp_path / "notice.stl"
     trimesh.creation.box(extents=BOX_EXTENTS).export(stl)
 
-    with pytest.warns(UserWarning, match="axis convention"):
-        stl_to_design_space(str(stl), pitch=1.0)
+    original = ac._WARNED
+    ac._WARNED = False  # reset session-once flag for a deterministic check
+    try:
+        with pytest.warns(UserWarning, match="axis convention"):
+            stl_to_design_space(str(stl), pitch=1.0)
 
-    # A second STL operation must NOT warn again (once per session).
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        stl_to_design_space(str(stl), pitch=1.0)
+        # A second STL operation must NOT warn again (once per session).
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            stl_to_design_space(str(stl), pitch=1.0)
+    finally:
+        ac._WARNED = original  # leave no global state behind for other tests

--- a/tests/test_stl_orientation.py
+++ b/tests/test_stl_orientation.py
@@ -1,0 +1,76 @@
+"""STL axis-convention tests.
+
+Lock the ``(x, y, z)`` <-> ``(nely, nelx, nelz)`` mapping at the STL boundary: an STL's
+x-axis must map to the domain's x (``nelx``) on import, and back to the mesh's x on export.
+These guard the 0.2.0 fix from silently regressing to the old transposed behaviour. They
+need ``trimesh`` (import) and ``scikit-image`` (export), both core dependencies; the test
+is skipped if either is unavailable, mirroring the HAS_CUPY guard used for the GPU tests.
+"""
+
+import numpy as np
+import pytest
+
+trimesh = pytest.importorskip("trimesh")
+pytest.importorskip("skimage")
+
+from pytopo3d.utils.export import voxel_to_stl
+from pytopo3d.utils.import_design_space import stl_to_design_space
+
+# An intentionally asymmetric box so every axis has a distinct length:
+# x is the longest, y the shortest, z in between.
+BOX_EXTENTS = [24, 6, 12]
+
+
+def test_stl_import_maps_x_to_nelx(tmp_path):
+    """A box longer in x than y must voxelize to a mask whose nelx axis is the long one."""
+    stl = tmp_path / "xlong.stl"
+    trimesh.creation.box(extents=BOX_EXTENTS).export(stl)
+
+    mask = stl_to_design_space(str(stl), pitch=1.0)
+    nely, nelx, nelz = mask.shape
+
+    # x is the longest CAD dimension -> nelx (axis 1) is the largest count;
+    # y is the shortest -> nely (axis 0) is the smallest.
+    assert nelx > nelz > nely
+
+
+def test_stl_export_maps_nelx_to_x():
+    """Exporting a (nely, nelx, nelz) block must put the long nelx axis on the mesh's x."""
+    # nelx (axis 1) is the long axis; nely (axis 0) is the short one.
+    block = np.ones((6, 24, 12), dtype=float)
+    mesh = voxel_to_stl(block, output_file=None, smooth_mesh=False, fix_mesh=False)
+
+    ex, ey, ez = mesh.extents  # trimesh extents are in CAD (x, y, z) order
+    assert ex > ez > ey
+
+
+def test_stl_round_trip_preserves_orientation(tmp_path):
+    """Import then export must return a mesh with the same axis-aspect order (no net flip)."""
+    stl = tmp_path / "block.stl"
+    trimesh.creation.box(extents=BOX_EXTENTS).export(stl)
+
+    mask = stl_to_design_space(str(stl), pitch=1.0).astype(float)
+    mesh = voxel_to_stl(mask, output_file=None, smooth_mesh=False, fix_mesh=False)
+
+    ex, ey, ez = mesh.extents
+    # Same ordering as the original box extents (x > z > y).
+    assert ex > ez > ey
+
+
+def test_axis_change_notice_fires_once(tmp_path):
+    """The 0.2.0 transition notice must fire on first STL use, then stay silent."""
+    import warnings
+
+    import pytopo3d.utils.axis_convention as ac
+
+    ac._WARNED = False  # reset session-once flag for a deterministic check
+    stl = tmp_path / "notice.stl"
+    trimesh.creation.box(extents=BOX_EXTENTS).export(stl)
+
+    with pytest.warns(UserWarning, match="axis convention"):
+        stl_to_design_space(str(stl), pitch=1.0)
+
+    # A second STL operation must NOT warn again (once per session).
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        stl_to_design_space(str(stl), pitch=1.0)


### PR DESCRIPTION
## What & why

STL import/export read trimesh's `(x, y, z)` voxel grid directly as the solver's internal `(nely, nelx, nelz)` layout, so an STL's x-axis silently became the domain's y-axis. For any non-symmetric part this placed the default supports/loads and JSON obstacles on the wrong faces, and made the matplotlib view disagree with the exported STL. This PR makes the STL boundary use the same `x`/`y` meaning as the rest of the library.

## Changes

- **Fix (breaking):** `stl_to_design_space` (import) and `voxel_to_stl` / `voxel_to_stl_tpms` (export) now swap the first two axes so an STL's x maps to the domain's x (`nelx`), consistent with the `nelx`/`nely` arguments, JSON obstacle `center`, and `force_field`.
- **Transition notice:** a one-time `UserWarning` on the first STL import/export flags this change (removed in 0.3.0), so upgraders are not surprised silently.
- **Docs:** new "Coordinate system and axis conventions" section in the README, covering the default load direction (`-z`, z-up), how it relates to MATLAB `top3d`'s `-y`, and a `force_field` recipe to reproduce the canonical `top3d` cantilever.
- **Cleanup:** corrected the misleading default-load comment; removed the unused `calculate_boundary_positions` helper.
- **Tests:** added `tests/test_stl_orientation.py` (import/export orientation + the one-time notice).
- **Version:** `0.1.2` → `0.2.0`.

## Impact & migration

Any STL import/export workflow is affected — results match 0.1.x only for parts that are symmetric under an `x` <-> `y` swap. Non-STL (pure-array) usage is **unchanged**: the numerical core and the golden-master result are byte-identical. To reproduce pre-0.2.0 results, pin `pytopo3d==0.1.2`.

## Verification

- Golden-master regression passes (core unchanged).
- New STL orientation + notice tests pass.
- Ran the repo's `run_with_stl_export.sh` example end-to-end: the visualization and exported STL agree, and the exported STL's x-extent matches `nelx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
