### PR TITLE
Docs: unify markdown wrapping + make RELEASING.md the release source of truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,14 +86,7 @@ Everything committed here is public. Keep machine- and environment-specific deta
 
 ## Releases
 
-Publishing is automated. Creating a **GitHub Release** triggers `.github/workflows/publish.yml`, which builds the sdist + wheel and uploads to PyPI via **Trusted Publishing** (OIDC — no stored token). To cut a release:
-
-1. Bump `version` in `pyproject.toml` (PyPI rejects re-uploading an existing version).
-2. Create a GitHub Release with tag `vX.Y.Z`.
-
-**Publishing is irreversible** — a PyPI version can never be re-uploaded or fully deleted — so treat it as a confirm-once, no-undo step.
-
-Version policy (pre-1.0): a **breaking** change is a MINOR bump (the 0.2.0 STL axis fix); bug-fix-only releases are PATCH bumps. Release numbers are assigned independently of the README roadmap milestones.
+Release cadence, versioning (SemVer), the per-release checklist, and the publish steps live in **`RELEASING.md`** — follow it when cutting a release. The one rule worth repeating here: **publishing is irreversible** (a PyPI version can never be re-uploaded or fully deleted), so the version bump + GitHub Release is a confirm-once step.
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -104,36 +104,21 @@ The main optimization parameters are:
 
 ### Coordinate System and Axis Conventions
 
-PyTopo3D uses a right-handed Cartesian `(x, y, z)` convention with `z` as the vertical axis.
-`x`, `y`, `z` mean the same thing across the whole public surface:
+PyTopo3D uses a right-handed Cartesian `(x, y, z)` convention with `z` as the vertical axis. `x`, `y`, `z` mean the same thing across the whole public surface:
 
 - `nelx`, `nely`, `nelz` count elements along x, y, z.
 - JSON obstacle `center`/`size` and `force_field` components `[Fx, Fy, Fz]` are in `(x, y, z)` order.
 - The default load is a downward `-z` force along the far-x bottom edge (`x = nelx`, `z = 0`, spanning all `y`); the default support fixes the entire `x = 0` face.
 
-Internally, density and mask arrays are stored as `(nely, nelx, nelz)` — the y-axis comes
-first — a layout inherited from the MATLAB `top3d` reference. So when you build a mask by
-hand, index it as `mask[y, x, z]`. STL import and export transpose the first two axes for
-you, so an STL's x-axis maps to the domain's `x` (`nelx`).
+Internally, density and mask arrays are stored as `(nely, nelx, nelz)` — the y-axis comes first — a layout inherited from the MATLAB `top3d` reference. So when you build a mask by hand, index it as `mask[y, x, z]`. STL import and export transpose the first two axes for you, so an STL's x-axis maps to the domain's `x` (`nelx`).
 
-> **Changed in 0.2.0:** STL import/export now map an STL's x-axis to the domain's x-axis.
-> Before 0.2.0 they were transposed, so **any** STL import/export workflow now produces
-> different results (identical to 0.1.x only for `x`<->`y`-symmetric parts); non-STL usage
-> is unchanged. To reproduce pre-0.2.0 results, pin `pytopo3d==0.1.2`. 0.2.0 emits a
-> one-time warning on first STL use. See the [CHANGELOG](CHANGELOG.md).
+> **Changed in 0.2.0:** STL import/export now map an STL's x-axis to the domain's x-axis. Before 0.2.0 they were transposed, so **any** STL import/export workflow now produces different results (identical to 0.1.x only for `x`<->`y`-symmetric parts); non-STL usage is unchanged. To reproduce pre-0.2.0 results, pin `pytopo3d==0.1.2`. 0.2.0 emits a one-time warning on first STL use. See the [CHANGELOG](CHANGELOG.md).
 
 #### Default load direction vs MATLAB `top3d`
 
-The default load is `-z` (z-up), consistent with the CAD/STL convention used everywhere else
-in PyTopo3D. The MATLAB `top3d` reference instead loads in `-y`: its vertical axis is `y`,
-inherited from the 2D `top88`/`top99` lineage. The two default cantilevers are therefore
-related by a `y` <-> `z` swap (PyTopo3D bends in the `x-z` plane, `top3d` bends in `x-y`).
-PyTopo3D keeps `-z` on purpose, since z-up is the CAD/STL convention and stays internally
-consistent with the rest of the framework.
+The default load is `-z` (z-up), consistent with the CAD/STL convention used everywhere else in PyTopo3D. The MATLAB `top3d` reference instead loads in `-y`: its vertical axis is `y`, inherited from the 2D `top88`/`top99` lineage. The two default cantilevers are therefore related by a `y` <-> `z` swap (PyTopo3D bends in the `x-z` plane, `top3d` bends in `x-y`). PyTopo3D keeps `-z` on purpose, since z-up is the CAD/STL convention and stays internally consistent with the rest of the framework.
 
-To set up a `top3d`-style cantilever (a downward `-y` load at the free-end tip, bending in
-the `x-y` plane), pass a `force_field`. The default supports already match `top3d`, so only
-the load differs:
+To set up a `top3d`-style cantilever (a downward `-y` load at the free-end tip, bending in the `x-y` plane), pass a `force_field`. The default supports already match `top3d`, so only the load differs:
 
 ```python
 import numpy as np
@@ -145,11 +130,7 @@ force_field[0, nelx - 1, :, 1] = -1.0  # -y load on the far-x tip elements (y=0 
 result = top3d(nelx, nely, nelz, 0.3, 3.0, 1.5, 0.5, force_field=force_field)
 ```
 
-Note: `force_field` is **element**-based — `build_force_vector` spreads each element's force
-over its 8 corner nodes — so this loads the tip *elements* rather than the exact nodal edge
-that MATLAB `top3d` uses (the total magnitude also differs). It reproduces the load direction
-and bending plane, which is what matters for orientation comparison, not `top3d`'s exact
-nodal load.
+Note: `force_field` is **element**-based — `build_force_vector` spreads each element's force over its 8 corner nodes — so this loads the tip *elements* rather than the exact nodal edge that MATLAB `top3d` uses (the total magnitude also differs). It reproduces the load direction and bending plane, which is what matters for orientation comparison, not `top3d`'s exact nodal load.
 
 ### Command-line Interface
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,6 @@
 # Releasing PyTopo3D
 
-PyTopo3D publishes to [PyPI](https://pypi.org/project/pytopo3d/) automatically when a GitHub
-Release is published — see `.github/workflows/publish.yml` (PyPI Trusted Publishing via OIDC, no
-stored token).
+PyTopo3D publishes to [PyPI](https://pypi.org/project/pytopo3d/) automatically when a GitHub Release is published — see `.github/workflows/publish.yml` (PyPI Trusted Publishing via OIDC, no stored token).
 
 ## When to release
 
@@ -11,10 +9,7 @@ Cut a release only when one of these holds; otherwise let changes accumulate on 
 - **Milestone** — a roadmap milestone's work has landed (see the Roadmap in the README).
 - **Urgent user-facing fix** — install-broken, a crash, data loss, or a security issue.
 
-**Merge ≠ release.** Merge PRs as soon as they are ready, but do not cut a release per PR. Batch
-related changes — especially fixes in the *same subsystem* — into one release. (For example, the
-`0.2.0` STL axis-convention fix and the `0.2.1` STL-resolution fix touched the same subsystem and
-ideally would have shipped together as one release.)
+**Merge ≠ release.** Merge PRs as soon as they are ready, but do not cut a release per PR. Batch related changes — especially fixes in the *same subsystem* — into one release. (For example, the `0.2.0` STL axis-convention fix and the `0.2.1` STL-resolution fix touched the same subsystem and ideally would have shipped together as one release.)
 
 ## Versioning (SemVer)
 
@@ -22,30 +17,24 @@ ideally would have shipped together as one release.)
 
 - **PATCH** (`0.2.0 → 0.2.1`) — backwards-compatible bug fixes.
 - **MINOR** (`0.1.x → 0.2.0`) — new features, **or a breaking change** (permitted in `0.x`).
-- A release number should map to a meaningful unit of change. Maintenance/correctness releases take
-  numbers independently of the Roadmap's feature-milestone numbers; on a collision, push the
-  roadmap milestone up rather than renaming the release.
+- A release number should map to a meaningful unit of change. Maintenance/correctness releases take numbers independently of the Roadmap's feature-milestone numbers; on a collision, push the roadmap milestone up rather than renaming the release.
 
 ## Checklist for every release
 
 - [ ] Bump `version` in `pyproject.toml` (PyPI rejects re-uploading an existing version).
 - [ ] Add a `CHANGELOG.md` section; put **breaking changes** at the top with a migration note.
-- [ ] For a silently-changed behaviour, emit a one-time transition warning for one release and
-      remove it the next (see the `0.2.0` STL axis-convention change for the pattern).
+- [ ] For a silently-changed behaviour, emit a one-time transition warning for one release and remove it the next (see the `0.2.0` STL axis-convention change for the pattern).
 - [ ] CI (the CPU test matrix) is green on `main`.
 - [ ] For a risky breaking change, consider shipping a release candidate (e.g. `0.3.0rc1`) first.
 
 ## How to publish
 
 1. Make sure `pyproject.toml` `version` and `CHANGELOG.md` are updated and merged to `main`.
-2. Create a GitHub Release whose tag is `vX.Y.Z`, targeting `main`. Publishing the release triggers
-   `publish.yml`, which builds the sdist + wheel and uploads them via Trusted Publishing.
-3. Verify the new version is live at <https://pypi.org/simple/pytopo3d/>. **Do not** trust the JSON
-   API at `/pypi/pytopo3d/json` for this — it is heavily cached and can lag for minutes.
+2. Create a GitHub Release whose tag is `vX.Y.Z`, targeting `main`. Publishing the release triggers `publish.yml`, which builds the sdist + wheel and uploads them via Trusted Publishing.
+3. Verify the new version is live at <https://pypi.org/simple/pytopo3d/>. **Do not** trust the JSON API at `/pypi/pytopo3d/json` for this — it is heavily cached and can lag for minutes.
 
 ## Reproducibility
 
-- **Never yank old versions.** PyTopo3D is used in research; `pip install pytopo3d==<old>` must keep
-  working so past results remain reproducible.
+- **Never yank old versions.** PyTopo3D is used in research; `pip install pytopo3d==<old>` must keep working so past results remain reproducible.
 
 > Publishing is irreversible: a PyPI version can never be re-uploaded or fully deleted.


### PR DESCRIPTION
## What

A documentation-consistency pass across the repo's markdown:

1. **README** — reflow the "Coordinate System and Axis Conventions" section to one paragraph per line (the rest of the README already uses that style).
2. **RELEASING.md** — reflow to one paragraph per line, matching the README/AGENTS style.
3. **AGENTS.md** — its "Releases" section was a condensed duplicate of `RELEASING.md`; replace it with a pointer to `RELEASING.md` plus the irreversibility caveat, so the release process has a single source of truth instead of two drifting copies.

## Why

Markdown added by tooling was hard-wrapped at ~88 columns while the original author's prose keeps each paragraph on one line; the mixed style was only visible in the raw source (GitHub renders repository `.md` with soft line breaks, so the rendered pages are unchanged). The AGENTS.md/RELEASING.md overlap also risked drift.

## Scope

No wording changes beyond the AGENTS.md Releases pointer. `CHANGELOG.md` (a release log) is intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
