### PR TITLE
Add .zenodo.json for software-archival DOI metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,14 @@
+{
+  "upload_type": "software",
+  "title": "PyTopo3D: A Python Framework for 3D SIMP-based Topology Optimization",
+  "description": "A Python framework for 3D structural topology optimization using the SIMP (Solid Isotropic Material with Penalization) method, with support for obstacle regions, STL design-space import/export, and optional CUDA (CuPy) GPU acceleration.",
+  "creators": [
+    {"name": "Kim, Jihoon"},
+    {"name": "Kang, Namwoo"}
+  ],
+  "license": "MIT",
+  "keywords": ["topology optimization", "SIMP", "structural optimization", "3D", "finite element"],
+  "related_identifiers": [
+    {"identifier": "arXiv:2504.05604", "relation": "isSupplementTo", "scheme": "arxiv"}
+  ]
+}


### PR DESCRIPTION
## What

Add `.zenodo.json` so that, once the repo is connected to Zenodo, each GitHub Release is archived with a clean, consistent metadata record (and a citable DOI). Fields mirror `CITATION.cff` / `pyproject.toml` (authors, MIT, keywords) and link the arXiv paper.

## Why

Reproducibility / archival — a Zenodo DOI permanently pins "these results were produced with PyTopo3D vX.Y.Z", independent of whether the GitHub repo still exists. This is **not** primarily a citation-count lever; the arXiv paper remains the main citation.

## One-time manual step (owner) — required for any of this to take effect

`.zenodo.json` alone does nothing until the repo is linked to Zenodo:

1. Sign in to https://zenodo.org with the `jihoonkim888` GitHub account (authorize Zenodo's GitHub app).
2. On https://zenodo.org/account/settings/github/ , flip the **PyTopo3D** repository toggle to **On**.
3. Create the next GitHub Release — Zenodo archives it and mints a DOI. (Past releases are not auto-archived; only releases made after the toggle is on.)
4. Zenodo issues two DOIs: a *version* DOI (this release) and a *concept* DOI (always resolves to the latest). Use the **concept DOI** for a README/CITATION badge.

## Follow-up (me)

Once you have the concept DOI, paste it and I'll add the Zenodo DOI badge to the README and a `doi:` field to `CITATION.cff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)