### PR TITLE
Release 0.2.2 (docs/metadata + Zenodo DOI bootstrap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,23 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.2] - 2026-06-15
+
+A maintenance release with no functional code changes. Cut as a one-off — outside the
+normal "milestone or urgent fix" cadence — to bootstrap Zenodo archival (the project's
+first software DOI) and to ship the documentation and project-metadata work that has
+accumulated since 0.2.1.
+
+### Added
+
+- `CITATION.cff` (GitHub's "Cite this repository") and status badges in the README.
+- `AGENTS.md` / `CLAUDE.md` contributor & agent guide, and a `RELEASING.md` release guide.
+- `.zenodo.json` so that published GitHub Releases are archived to Zenodo with a citable DOI.
+
+### Fixed
+
+- README citation: a malformed BibTeX entry (missing comma after the cite key) and the
+  prose publication year (2024 → 2025).
 
 ### Removed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytopo3d"
-version = "0.2.1"
+version = "0.2.2"
 description = "3D SIMP Topology Optimization Framework for Python"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## What

Version bump `0.2.1 → 0.2.2` + CHANGELOG, to cut the 0.2.2 release.

## Why

A one-off maintenance release, deliberately outside RELEASING.md's normal "milestone or urgent fix" cadence, to:

- **Bootstrap Zenodo archival** — mint the project's first software DOI. The repo is now connected to Zenodo and `.zenodo.json` is in place.
- **Ship the docs/metadata accumulated since 0.2.1** — CITATION.cff, README badges, AGENTS.md/CLAUDE.md, RELEASING.md, .zenodo.json — plus the dead-code removal of the two broken alternate entry points.

No functional code change; the numerical core / golden master is unchanged. The one-off rationale is recorded in the CHANGELOG, **not** in RELEASING.md — a single event doesn't belong in the standing policy.

## After merge

Per RELEASING.md: create GitHub Release `v0.2.2` targeting `main` → `publish.yml` uploads to PyPI and Zenodo archives the release and mints the DOI. Then the Zenodo DOI badge goes on the README and a `doi:` field on CITATION.cff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)