### PR TITLE
Add Zenodo DOI badge + CITATION.cff doi (concept DOI)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,6 +7,7 @@ authors:
   - family-names: Kang
     given-names: Namwoo
 license: MIT
+doi: "10.5281/zenodo.20697949"
 url: "https://github.com/jihoonkim888/PyTopo3D"
 repository-code: "https://github.com/jihoonkim888/PyTopo3D"
 preferred-citation:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/pytopo3d)](https://pypi.org/project/pytopo3d/)
 [![CI](https://github.com/jihoonkim888/PyTopo3D/actions/workflows/ci.yml/badge.svg)](https://github.com/jihoonkim888/PyTopo3D/actions/workflows/ci.yml)
 [![arXiv](https://img.shields.io/badge/arXiv-2504.05604-b31b1b.svg)](https://arxiv.org/abs/2504.05604)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20697949.svg)](https://doi.org/10.5281/zenodo.20697949)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 ![Design optimization with boundary conditions](assets/optimization_animation.gif)


### PR DESCRIPTION
## What

Add the Zenodo **concept DOI** (`10.5281/zenodo.20697949`) now that `v0.2.2` is archived: a README DOI badge next to arXiv, and a top-level `doi:` field in `CITATION.cff`.

## Why

Completes the Zenodo archival loop — the software now has a citable, version-stable DOI surfaced on the repo page and in the citation metadata. The concept DOI always resolves to the latest archived release, so it never needs updating per version. Badge SVG and `doi.org` resolution both verified (HTTP 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)