### PR TITLE
Bump GitHub Actions to Node 24 (checkout v6, setup-python v6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,10 +29,10 @@ jobs:
       id-token: write  # required for Trusted Publishing (OIDC)
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## What

Bump `actions/checkout@v4 → @v6` and `actions/setup-python@v5 → @v6` in `ci.yml` and `publish.yml`.

## Why

v4/v5 run on Node 20, which GitHub is deprecating (Node 24 forced from 2026-06-16); the publish.yml run on 2026-06-15 raised the deprecation annotation. checkout reached Node 24 at v5 and setup-python at v6 — both `@v6` are Node 24 (verified on the release notes). Action options (`cache`, `python-version`) and the publish logic are unchanged; no functional change.

## Verification

CI on this branch runs with the new action versions, so a green run here confirms the bump works and the Node 20 deprecation warning is cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)