### PR TITLE
Fix force_field x/y transpose; extract a ComplianceEvaluator seam (0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0] - 2026-06-16
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Force-direction x/y transpose.** `force_field` components `[Fx, Fy, Fz]` now act along
+  the correct axes. The `build_edof` rewrite in the commit that added custom `force_field`
+  support (the same change that moved the default load from `-y` to `-z`) silently swapped
+  the H8 element's first two local axes, so a user-supplied `Fx` acted along the **y**
+  (`nely`) axis and `Fy` along **x**. This was invisible to the default `-z` load, every
+  shipped cantilever example, and the golden master (all `-z` / `x`<->`y`-symmetric), so only
+  `force_field` loads with distinct `Fx` vs `Fy` were affected.
+
+  **Impact:** non-symmetric `force_field` loads carrying both x and y components change. The
+  default load, `-z`-only loads, supports, obstacle/geometry positions, and the golden-master
+  result are byte-identical (verified: max abs difference ~4e-13). The README's `force_field`
+  cantilever recipe now behaves as documented (a `-y` tip load bending in the x-y plane). To
+  reproduce the old (transposed) behavior, pin the previous release.
+
+### Added
+
+- `tests/test_force_direction.py` — locks the public `(x, y, z)` force-direction convention
+  (on an x-long beam, `Fx` is axial while `Fy`/`Fz` bend), so the transpose cannot regress.
+
 ## [0.2.2] - 2026-06-15
 
 A maintenance release with no functional code changes. Cut as a one-off — outside the

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ A comprehensive Python implementation of 3D Topology Optimization based on SIMP 
   - [Citation](#citation)
   - [Roadmap](#roadmap)
     - [Version 0.2.0 (Performance \& Coordinate Fix) — released](#version-020-performance--coordinate-fix--released)
-    - [Version 0.3.0 (Core Functionality \& Interface)](#version-030-core-functionality--interface)
-    - [Version 0.4.0 (Pre-release Stabilization)](#version-040-pre-release-stabilization)
+    - [Version 0.3.0 (Force-direction Fix)](#version-030-force-direction-fix)
+    - [Version 0.4.0 (Core Functionality \& Interface)](#version-040-core-functionality--interface)
+    - [Version 0.5.0 (Pre-release Stabilization)](#version-050-pre-release-stabilization)
     - [Version 1.0.0 (Stable Release)](#version-100-stable-release)
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -448,12 +448,15 @@ Below is the roadmap for future releases of PyTopo3D:
 - ✅ **GPU Acceleration**: CUDA acceleration via CuPy for faster optimization on NVIDIA GPUs
 - ✅ **STL coordinate-convention fix**: consistent `x`/`y` axis handling on STL import/export (see [CHANGELOG](CHANGELOG.md))
 
-### Version 0.3.0 (Core Functionality & Interface)
-- **Interactive GUI**: Basic graphical user interface for parameter configuration and visualization (replacing the current `matplotlib`-based visualization which slows down with high voxel counts)
-- **Optimization for Mass Minimization**
-- **Improved Convergence Methods**
+### Version 0.3.0 (Force-direction Fix)
+- **`force_field` x/y transpose fix**: `Fx` and `Fy` now act along the correct axes (a regression where `Fx` acted along the `y` axis); see [CHANGELOG](CHANGELOG.md). Breaking only for `force_field` loads carrying distinct `Fx`/`Fy`; default `-z` loads and the golden master are unchanged.
 
-### Version 0.4.0 (Pre-release Stabilization)
+### Version 0.4.0 (Core Functionality & Interface)
+- **Interactive GUI**: Basic graphical user interface for parameter configuration and visualization (replacing the current `matplotlib`-based visualization which slows down with high voxel counts)
+- **Optimization for Mass Minimization** — minimize mass/volume under a performance (compliance) constraint
+- **Improved Convergence Methods** *(conditional)* — penalty continuation / projection, brought in alongside mass minimization only where an observed need (residual gray regions, poor local minima) justifies them, rather than as a standalone change
+
+### Version 0.5.0 (Pre-release Stabilization)
 - **API Stabilization**: Finalize API design for 1.0 release
 - **Comprehensive Testing**: Extensive test suite for all components (probably with `pytest`). *An initial `pytest` suite (CPU core + packaging guards) and GitHub Actions CI landed early, in 0.1.1.*
 - **Performance Benchmarking**: Establish baseline performance metrics

--- a/docs/literature-reviews/0.3.0-implementation-plan.md
+++ b/docs/literature-reviews/0.3.0-implementation-plan.md
@@ -1,0 +1,86 @@
+# PyTopo3D 0.3.0 — Implementation plan (core: mass minimization + optional convergence aids)
+
+Companion to `docs/literature-reviews/optimizer-survey.md`. Grounded in the current code at `pytopo3d/core/optimizer.py`, `pytopo3d/utils/oc_update.py`, and `tests/`. **This is the confirmed plan** after a two-camp cross-review (Claude + GPT; Gemini unavailable) — the findings are folded in below and noted as `[xref Fn]`.
+
+## P0. Guiding principle
+The current base optimizer (OC + density filter + fixed penalty; loop `while change > tolx and loop < maxloop`, `tolx=0.01`, `maxloop=2000`) shows **no observed convergence failure** for the compliance problems it is run on — matching the `top88`/`top3d` lineage it ports. [xref F6: the `maxloop` cap can silently truncate a non-converging run, so "no failure observed" partly reflects the cap; do not read it as a proof of convergence.] We therefore do **not** add convergence machinery speculatively. The only roadmap item that *forces* new optimizer code is **mass minimization** (a nonlinear constraint the single-multiplier OC cannot express).
+
+## P1. Scope of 0.3.0
+- **(B) Mass minimization** under a compliance constraint — the load-bearing new feature.
+- **(A) Optional convergence aids** (penalty continuation; gray-scale / Heaviside projection) — opt-in, default OFF, added **only when (B) or a manufacturability need actually exercises them** (tier-③). [xref F7: this consciously **supersedes** the survey's "ship convergence first," per the decision to not build against an unobserved problem. Follow-up: the README roadmap lists "Improved Convergence Methods" as a committed 0.3.0 bullet — soften it to "conditional / coupled to mass-min" so the docs agree.]
+- Out of scope: GUI; stress / manufacturability / multiphysics (later releases).
+
+## P2. Optimizer decision: **adopt NLopt** (not build)
+Build-vs-adopt was decided against build by all five criteria (the optimizer is infrastructure, not PyTopo3D's contribution; an adoptable option fits license/platform/integration; its cost is off the performance-critical path; no byte-control need the package can't meet; building is not the goal). An optimizer we could write today (single-constraint, CPU, fitted to the current loop) is **not** the optimizer a future product needs (parallel/GPU/large-scale/multi-constraint) — so building now is throwaway, not a first brick.
+
+1. **Adopt MMA via `nlopt`** (PyPI). For mass-min the constraint is a single **inequality** (`c ≤ C*`), which `LD_MMA` supports; use `LD_CCSAQ` (the conservative, globally-convergent CCSA/GCMMA-family variant in NLopt) where extra robustness is wanted.
+2. **License** [xref G5]: the MMA *source* in NLopt is MIT (S.G. Johnson's independent reimplementation of Svanberg 2002, verified against `nlopt/src/algs/mma/README`); the *installed wheel* is in practice **LGPL** (bundles the `luksan` directory). Both are **dependency-safe** — an LGPL/MIT package consumed as a normal pip dependency does not propagate copyleft to PyTopo3D's own code. Ship as an optional extra (`pip install pytopo3d[mma]`), import-guarded (`HAS_NLOPT`) like the existing `HAS_CUPY` idiom.
+3. **Rejected:** GPL MMA ports (Svanberg/Deetman `GCMMA-MMA-Python`, `mmapy` — verified GPL-3.0); NN/autodiff TO as the optimizer (Woldseth et al. 2022: no quality gain, and PyTopo3D already has analytic sensitivities so autodiff's main benefit does not apply); hand-rolling MMA now (throwaway, per P2 above).
+4. **Fallback, documented not adopted:** IPOPT via `cyipopt` (EPL-2.0) for a full interior-point NLP; NLopt also offers SLSQP, COBYLA, augmented-Lagrangian, and equality-constraint support for later needs.
+
+## P3. Architecture — optimizer-agnostic seam [xref F3, the cross-review's #1 finding]
+NLopt is **solver-driven**: it owns the iteration loop and calls back for the objective/constraint values + gradients at each candidate `x`. PyTopo3D's current loop is **framework-driven** (the `while` loop owns iteration; OC is a per-step `update(...) -> x_new`). The interface must support **both** integration modes, and the physics must be factored out so the kernel is swappable (the one thing the long-term product vision makes non-negotiable — see P8).
+
+1. **Physics evaluator (the swappable seam).** Factor the per-iteration physics — assemble `K`, FE solve, compliance `c`, sensitivities `dc`/`dv`, filter chain-rule — into one evaluator callable. Both integration modes call it; no optimizer owns it.
+2. **Two integration modes behind one `Optimizer` protocol:**
+   - *framework-owns-loop* (OC): the existing `optimality_criteria_update(...)` per step — **unchanged**.
+   - *solver-owns-loop* (NLopt): hand NLopt an objective callback and an inequality-constraint callback (each invoking the evaluator), then call `opt.optimize(x0)`.
+3. **Mass-min adapter — explicit, because roles swap** (NOT "just reuse `dc`/`dv`"):
+   - **Objective = mass/volume**; its gradient is a (filtered) near-constant field — **a new quantity**, not today's `dv`.
+   - **Constraint = `c(x) − C* ≤ 0`**; gradient = today's `dc`, but used as the **constraint Jacobian**. Plumb the scalar `c` (currently computed at `optimizer.py:229` then discarded) into the constraint callback.
+   - **Sign/convention:** NLopt minimizes the objective and expects inequality constraints in `g(x) ≤ 0` form — match it exactly.
+   - **Un-perturb `dv`:** drop the OC-only `dv += 1e-9` guard (`optimizer.py:236`) when feeding MMA; that artifact belongs to OC's division, not to the true volume gradient.
+   - **Scaling/normalization:** normalize objective and constraint magnitudes (`c` is O(10²–10⁴), volume O(1)). MMA convergence is scaling-sensitive — this is the most common "runs but produces garbage" cause and must be designed, not discovered.
+4. **Backward compatibility** [xref G2]: extend `top3d()` with **keyword** args appended after the current signature — `objective: "compliance"|"mass" = "compliance"`, `compliance_limit: float|None = None`, `optimizer: "oc"|"mma" = "oc"`. The existing **required positional** `disp_thres` (and positional order) is preserved; default call is unchanged. `objective="mass"` auto-selects `optimizer="mma"`.
+5. **Optional convergence aids (default OFF):** `continuation: bool=False` (penalty ramp, ported from **Liu & Tovar 2014, §6.1.6 / Eq. 43**: `p=1` for `k≤20`, then `min(pmax, 1.02·p)` — verified against the paper this session); `projection_beta: float|None=None` (gray-scale / Heaviside). Gated so the default path is unchanged.
+
+## P4. Validation strategy ("how do we know correctness with no reference code?")
+A golden master only certifies values when an external oracle pins them. [xref G1: PyTopo3D's existing golden `tests/data/golden_small_case.npz` is **not** MATLAB-validated — it is a drift-locked **snapshot of PyTopo3D's own output** (scipy `spsolve` path), checked structurally, plus physical-invariant smoke tests. It catches drift and gross error, not "physically correct."] For self-authored features we test **properties the correct answer must satisfy**; we do not mint a new golden master for them (that would enshrine our own possibly-wrong output). The design below separates a **formulation- and optimizer-agnostic backbone** (extends unchanged to stress / manufacturability / multiphysics and to a future engine swap) from **problem-specific bonus checks** (do not generalize).
+
+### P4.1 The generalized backbone — every formulation re-runs all four
+1. **Finite-difference gradient check [R1, tier-①] — the foundational test.** Every analytic sensitivity (compliance `dc`, the mass-objective gradient, any future stress/physics gradient) is verified against central differences `(f(x+h·eᵢ) − f(x−h·eᵢ))/2h` at several random interior `x`, over an `h`-window (so truncation vs round-off is visible), with a relative-error gate. This directly catches the F3 risks (sign, scaling, missing filter chain-rule) that the higher-level checks alone would pass over (a wrong gradient still converges to a wrong-but-feasible point). A flipped sign **must** fail this test.
+2. **Closed-form absolute anchor [R2, tier-①].** At least one problem with an analytic optimum (e.g. a uniform-field or single-/two-bar minimum-weight case) pins the whole stack to ground truth. Relative checks alone are blind to a **shared/systematic** bug (both solvers consuming the same mis-scaled sensitivities agree and pass); the anchor is the only guard against that, and it upgrades the compliance path from "drift-locked snapshot" (G1) to physically anchored at ≥1 point.
+3. **Feasibility [tier-①].** Any constrained run returns a design satisfying its constraint(s) within tol (`c ≤ compliance_limit + tol` for mass-min; the analogous bound for any future constraint).
+4. **Cross-solver agreement [tier-②] = the engine-swap acceptance gate.** Two independent optimizers agree on the objective value within measured tolerance — `LD_MMA` vs `LD_CCSAQ` now; **the future owned/commercial engine vs NLopt later** (P8). The harness tests the *result/formulation*, not NLopt, so swapping the kernel behind the seam is certified by re-running this suite.
+
+### P4.2 Tolerance derivation [R3]
+Every `≈` / `tol` / `ε` is **derived from measured noise** (spread across two linear solvers / BLAS / a restart), never hand-picked. A tolerance is valid only if it is tight enough that the matching mutation test (P4.5) still fails — otherwise it is an unfalsifiable pass.
+
+### P4.3 Determinism & robustness
+- **Default OC path [F1]:** a new **strict** `np.array_equal` test asserts the M0 refactor leaves the OC default path bit-for-bit unchanged (the existing tolerant golden cannot certify this; it stays as the cross-version drift guard).
+- **MMA determinism [R4, tier-①]:** same input twice → identical output; lock it. (If MMA were nondeterministic, the ② tolerances and any MMA-path regression would be unstable.)
+- **Input-diversity matrix [R5]:** a small matrix (volfrac × mesh size × BC × obstacle-present × `force_field`-present); each cell must converge and stay feasible. Robustness = behaves across a range, not on one golden case.
+
+### P4.4 Problem-specific bonus checks (do NOT generalize — 0.3.0-local)
+- **Duality sanity bound [F2]:** mass-min at `compliance_limit=C*` (where `C*` = compliance-min optimum at volume `f`) must return `volume ≤ f + tol` **and** `c ≤ C* + tol` (no-worse-mass than the compliance-min iterate, which is itself feasible). One-directional; it does **not** assert "recovers volume ≈ f." Compliance↔volume-specific; not reused for stress/multi-constraint.
+- **Tolerant monotonicity [F5, tier-②]:** sweeping `C*`, `mass(C*_tight) ≥ mass(C*_loose) − ε` (slack absorbs different local minima under non-convexity).
+- **KKT residual [F4]:** informational diagnostic only — not a gate unless a concrete reduced-gradient residual (filtered vars, box+obstacle bounds, active constraint, scaling) is specified; NLopt does not expose multipliers.
+- **Continuation:** reproduce Liu & Tovar §6.1.6; plus a degenerate-config strict test (constant penalty schedule = current fixed-penalty path, `np.array_equal`).
+- **Projection:** grayness (Mnd) decreases vs none; sub-length-scale features absent; `beta→0` equals the unprojected field.
+
+### P4.5 Mutation discipline (every test above)
+Break the implementation (flip a gradient sign, drop the constraint, zero the scaling, perturb a tolerance's source) and confirm each test goes red. "It passes" is not coverage; "it fails when the code is wrong" is.
+
+### P4.6 Future formulations
+Each new physics/constraint (stress, manufacturability, multiphysics) re-runs the **P4.1 backbone** — finite-diff on its new sensitivity, a closed-form anchor where one exists, feasibility, cross-solver — plus its own bonus checks. The compliance-specific duality bound is **not** reused.
+
+## P5. Sequencing (milestones)
+- **M0 — Refactor to the swappable seam + stand up the backbone.** Extract the physics evaluator (P3.1); route OC through the `Optimizer` protocol's framework-owns-loop mode. Acceptance: strict default-path `np.array_equal` test (P4.3) passes and existing tolerant golden still passes; **finite-diff gradient check (R1/P4.1.1) on the existing compliance sensitivities passes**; **closed-form anchor (R2/P4.1.2) established** on the compliance path. (The backbone is built on the known-good problem *before* any new feature depends on it.)
+- **M1 — NLopt MMA backend on the existing compliance problem.** Solver-owns-loop mode wired to the evaluator. Acceptance: cross-solver `compliance(MMA) ≈ compliance(OC)` at pinned convergence (P4.1.4, tolerance per R3); MMA determinism (R4) locked.
+- **M2 — Mass-minimization formulation.** Add `objective="mass"`, `compliance_limit`, the role-swapped/scaled adapter (P3.3). Acceptance: **finite-diff check (R1) on the new mass-objective and compliance-constraint gradients**; feasibility (①); cross-solver `LD_MMA` vs `LD_CCSAQ` (②); duality sanity bound (②) + tolerant monotonicity (②), tolerances per R3; KKT residual reported as diagnostic; input-diversity matrix (R5) converges + feasible.
+- **M3 — Optional convergence aids (only if M2 surfaces gray / poor local minima).** Continuation/projection behind flags. Acceptance: degenerate-config strict equality; grayness-decrease; length-scale.
+
+## P6. Acceptance-check tiering (epistemic status)
+- **① Invariant (lock as an automated gate before building):** **finite-diff gradient check [R1]** on every analytic sensitivity; **closed-form anchor [R2]**; strict default-path `np.array_equal` test; **MMA determinism [R4]**; mass-min feasibility (`c ≤ C* + tol`); continuation degenerate-config strict equality; license = no GPL propagation in the dependency tree.
+- **② Calibrated (measure once, lock as no-regression floor):** **cross-solver agreement tolerance [= engine-swap gate]**; `compliance(MMA)` vs `compliance(OC)` tolerance at pinned convergence; duality sanity-bound `tol`; monotonicity slack `ε`; MMA iteration count on a reference case. All tolerances **derived from measured noise [R3]**, not hand-picked. **Re-measure whenever the physics/model changes** (a formulation change re-opens these; an observation/visualization change does not).
+- **③ Discovery (no preset pass/fail; observe then lock):** does mass-min actually produce gray / bad local minima that justify (A)?; magnitude of any convergence improvement from continuation/projection.
+
+## P7. Risks / open questions
+1. **SIMP non-convexity** weakens the duality check to a one-directional sanity bound; tolerances (②) must be measured from a baseline, not assumed.
+2. **GPU** [xref G3]: NLopt is CPU-only, so in solver-owns-loop mode the density field round-trips GPU→CPU each iteration. The transfer (≈ one `nele`-float array, e.g. ~8 MB at 1M elements) is **small relative to the FE/CG solve** that dominates, so it should not bottleneck — but measure on a large case (②). The OC path keeps its on-GPU update unchanged.
+3. **API freeze (0.4.0):** the `objective`/`compliance_limit`/`optimizer` keyword surface and the `Optimizer` protocol are freeze-sensitive — name them deliberately now.
+4. **Compliance-limit calibration:** mass-min needs a sensible `C*`; document the "run compliance-min first to calibrate" recipe, else the problem is ill-posed (`C*→0` ⇒ solid, `C*→∞` ⇒ empty).
+5. **Constraint scaling** (P3.3) is the highest-risk implementation detail; treat a scaling-sweep as part of M2, not an afterthought.
+
+## P8. Long-term product roadmap — the NLopt graduation trigger
+The vision is a GUI-complete TO product (Altair/Fusion class). That destination likely **outgrows NLopt** (CPU-serial-dense; commercial tools own or license scalable optimizers — Altair DUAL2/CONLIN, ANSYS SCP, Tosca MMA, COMSOL SNOPT/IPOPT). The optimizer-agnostic seam (P3) is precisely what makes that future swap contained: replace the kernel behind the `Optimizer` protocol without touching the product/GUI layer. **Trigger to graduate from NLopt to an owned/scalable or commercially-licensed optimizer:** (i) real workloads hit NLopt's CPU-serial-dense ceiling (need parallel/GPU/distributed for millions of elements); (ii) a convergence/robustness/manufacturing-constraint behavior NLopt lacks becomes a product differentiator; (iii) product direction + resources are validated. Until all three, NLopt behind the seam is the fastest path toward that destination — and the early product differentiation is the workflow/GUI/CAD/manufacturing layer, not the optimizer kernel.

--- a/docs/literature-reviews/0.3.0-implementation-plan.md
+++ b/docs/literature-reviews/0.3.0-implementation-plan.md
@@ -1,4 +1,8 @@
-# PyTopo3D 0.3.0 — Implementation plan (core: mass minimization + optional convergence aids)
+# PyTopo3D 0.4.0 — Implementation plan (core: mass minimization + optional convergence aids)
+
+> **Renumbered:** this milestone (mass minimization + convergence) ships as **0.4.0** — the
+> force-direction fix took 0.3.0. "0.3.0" below is the original label; the API-freeze
+> milestone called "0.4.0" below is now 0.5.0.
 
 Companion to `docs/literature-reviews/optimizer-survey.md`. Grounded in the current code at `pytopo3d/core/optimizer.py`, `pytopo3d/utils/oc_update.py`, and `tests/`. **This is the confirmed plan** after a two-camp cross-review (Claude + GPT; Gemini unavailable) — the findings are folded in below and noted as `[xref Fn]`.
 

--- a/docs/literature-reviews/optimizer-survey.md
+++ b/docs/literature-reviews/optimizer-survey.md
@@ -1,0 +1,164 @@
+# Decision Memo: Optimizer / update-scheme choice for PyTopo3D 0.3.0
+
+**Date:** 2026-06-16
+**Scope:** What optimizer should PyTopo3D adopt for the 0.3.0 roadmap items *Mass Minimization* and *Improved Convergence Methods*, and to enable the later (beyond-roadmap) constrained problems (stress, manufacturability, multiphysics)?
+**Purpose:** Decision support. Is "just use MMA" right, or is there a more elegant / better-fitting choice?
+**Method:** OpenAlex systematic discovery (primary literature) + primary-source verification of license terms (GitHub `LICENSE` files, PyPI) and commercial-tool optimizers (vendor docs). Every load-bearing claim is tagged with its source; unverifiable vendor internals are flagged.
+
+---
+
+## Executive summary
+
+**Most-used ≠ most-flashy, and here they reconcile: MMA *is* the right call — with two corrections to the naive "just `pip install` an MMA package" version.**
+
+1. **Adopt MMA, but via NLopt's MIT reimplementation — not the Svanberg/Deetman code.** The entire Svanberg lineage (his reference MATLAB, the popular `GCMMA-MMA-Python` port, the `mmapy` wheel) is **GPL-3.0** and cannot be bundled into a permissive public package. NLopt ships an **independent MIT-licensed MMA/CCSA** written from Svanberg's 2002 paper — this dissolves the license objection that would otherwise count against MMA. *(This corrects an earlier assumption that "MMA = unavoidable GPL baggage.")*
+
+2. **"Improved Convergence" is a separate, cheaper sub-decision that does *not* need MMA.** The convergence aids (penalty continuation, gray-scale / Heaviside-robust projection) are documented in PyTopo3D's own source paper (Liu & Tovar 2014) as drop-in extensions the base code never included. They are low-risk and license-free, but are brought in **conditionally — coupled to mass minimization**, only where an observed need justifies them (see `0.3.0-implementation-plan.md`, which supersedes the "ship convergence first" framing below). MMA is required by *mass minimization* (a nonlinear constraint), not by convergence.
+
+3. **The "more elegant modern" alternative (neural / differentiable TO) does not win on merit.** A Sigmund-group review reading the primary NN-TO literature (Woldseth et al. 2022) concludes neural reparameterization "involves no actual learning" — it is a conventional optimizer in disguise, with speed-ups that are really an implicit coarser filter. Autodiff's genuine value is *computing sensitivities*, which PyTopo3D already has analytically. So the modern-looking path adds cost without a demonstrated quality gain here.
+
+**Recommendation:** Treat 0.3.0 as two decisions. **(A)** Improve convergence by porting continuation + projection (no new optimizer, no license cost). **(B)** Add mass minimization (and lay the substrate for stress/multiphysics) with **MMA via the `nlopt` MIT dependency**, consuming PyTopo3D's existing analytic sensitivities. Keep **IPOPT (cyipopt, EPL-2.0)** as the documented fallback if a full general NLP solver is later wanted. Do **not** vendor any GPL MMA, and do not pursue NN/autodiff as *the optimizer*.
+
+---
+
+## 1. The question, split correctly
+
+The roadmap lists "Mass Minimization" and "Improved Convergence Methods" as two bullets. They impose very different optimizer requirements:
+
+| Roadmap item | Does it need a new optimizer? | Why |
+|---|---|---|
+| **Improved Convergence** | **No.** | Achievable with formulation-side aids (continuation on penalty, gray-scale / robust Heaviside projection) on top of the existing OC. These are in PyTopo3D's own source paper as extensions. |
+| **Mass Minimization** | **Yes.** | Puts a *nonlinear* quantity (compliance/stress) into the **constraint**. The classic OC update is a single-volume-constraint heuristic (one Lagrange multiplier found by bisection) and does not generalize. A general constrained optimizer is required. |
+
+This split is the crux: "just use MMA" answers (B) but over-serves (A).
+
+---
+
+## 2. Candidate landscape
+
+Density-based (SIMP) TO optimizers cluster into four families. Citations are OpenAlex `cited_by_count` as of 2026-06.
+
+### 2.1 Optimality Criteria (OC) and generalizations
+The classic update used by the educational MATLAB lineage — Sigmund's 99-line, Andreassen et al.'s 88-line (`W2141377530`, 1558 cites), and **Liu & Tovar's `top3d` (`W2048785994`, 622 cites) which PyTopo3D ports**. OC is derived from the KKT conditions of *single-volume-constrained compliance minimization*; it is tiny, dependency-free, and cheap (the bisection re-evaluates only volume, never the FE solve). It does **not** extend to a nonlinear constraint. "Generalized OC" variants exist (`W3140833829`, 2021, 36 cites) but remain niche.
+
+### 2.2 Method of Moving Asymptotes (MMA) and GCMMA — the field workhorse
+- **MMA** (Svanberg 1987, `W2062523101`, **5401 cites**, full-text abstract verified): each iteration builds and solves "a strictly convex approximating subproblem … controlled by so-called 'moving asymptotes', which may both stabilize and speed up the convergence." Handles arbitrary nonlinear objective + multiple nonlinear constraints.
+- **GCMMA** (Svanberg 2002, `W2153245297`, 1342 cites, abstract verified): globally convergent variant. Abstract states it is **proven to converge to KKT points**, each iterate feasible with lower objective, and — decisive for TO — "can be applied to problems with a very large number of variables (say 10⁴–10⁵) even if the Hessian matrices … are dense."
+- **Scale evidence:** Aage et al. (2017, *Nature*, `W2761536263`, 742 cites) used MMA with PETSc for *giga-voxel* (~10⁹-element) structural design — proof MMA is the large-scale production tool, not just a textbook method.
+
+### 2.3 General-purpose NLP solvers fed by sensitivities
+IPOPT (interior-point), SNOPT/SLSQP (SQP), NLopt. "Don't write an optimizer — hand the problem (objective + constraints + analytic gradients) to a battle-tested NLP solver." Common in research stacks (e.g. dolfin-adjoint/pyadjoint + IPOPT). Elegant and general; the trade-off is dependency/license weight (see §4) and, for dense SQP like SLSQP, poor scaling to 10⁴–10⁶ design variables.
+
+### 2.4 Differentiable / neural topology optimization
+- **Neural reparameterization** (Hoyer et al. 2019, arXiv:1909.04240): a CNN re-parameterizes the density field, optimized by L-BFGS.
+- **Direct NN design** (TOuNN, Chandrasekhar & Suresh 2020, `W3106486741`, 233 cites): a network *is* the design representation.
+- **Autodiff frameworks**: JAX-FEM (`W4379196907`, 2023, 97 cites), AuTO (`W3140287683`, 2021).
+- **Critical appraisal** (Woldseth, Aage, Bærentzen & Sigmund 2022, `W4298156653`, arXiv:2208.02563, 187 cites — full text read): strongly skeptical. Direct-design NNs give "poor designs, … expensive to obtain and … very restricted." Reparameterization "is not subjected to any actual learning … an example of using an ANN without the learning aspect"; apparent iteration savings may be "a result of the re-parameterisation causing a perceived larger filter radius or coarser mesh." Verdict: NN approaches today do **not** beat classical gradient-based density TO; their promise is *accelerating* the conventional loop (surrogate FEA), not replacing the optimizer.
+
+### 2.5 Why non-gradient (GA/PSO) is out of scope
+Sigmund 2011 (`W2056802356`, 453 cites; abstract verified, body paywalled): gradient-based TO solves "thousands and up to millions of design variables using a few hundred … function evaluations (and even less than 50 in some commercial codes)," whereas non-gradient methods "require orders of magnitude more function evaluations for extremely low resolution examples." Genetic-algorithm / particle-swarm optimizers are ruled out for the high-dimensional 3D regime PyTopo3D targets.
+
+---
+
+## 3. What commercial tools actually use (verified from vendor docs)
+
+This is the "commercial alignment" criterion, and it is decisive: **MMA (or an MMA-derived method) is the verified de-facto backbone for general/sensitivity-based topology optimization in 3 of 4 major tools.**
+
+| Tool | Method | Optimizer (verbatim from vendor doc) | Source |
+|---|---|---|---|
+| **COMSOL** Optimization Module | density-based | Gradient solvers: "SNOPT, IPOPT, MMA, and Levenberg–Marquardt." The MMA impl "is the globally convergent version … referred to as GCMMA." | doc.comsol.com |
+| **Altair OptiStruct** | SIMP | Topology **default = DUAL2**, "an enhanced version of the proprietary CONLIN dual optimizer"; MMA, MFD, SQP, DUAL also offered. | help.altair.com |
+| **Dassault SIMULIA Tosca / Abaqus** | condition-based + sensitivity-based | Sensitivity-based path "uses an algorithm based on the Method of Moving Asymptotes from Krister Svanberg." Fast path = controller (optimality-criteria). | docs (Abaqus 2024) |
+| **ANSYS Mechanical** | SIMP / level-set / mixable | OC "for a simple compliance objective … volume or mass constraint"; default class = **Sequential Convex Programming (SCP), "an extension of the method of moving asymptotes (MMA)."** | ansyshelp.ansys.com (2025 R1) |
+
+**Reading:** the *general constrained* path is MMA-or-MMA-derived almost everywhere (COMSOL GCMMA, Tosca MMA, ANSYS SCP-extends-MMA); the *fast/simple* path is OC (Tosca controller, ANSYS OC). Altair is the lone exception (proprietary CONLIN/DUAL2 — disclosed family, undisclosed internals). This mirrors the split in §1 exactly: OC for the simple volume-constrained case, MMA once constraints get richer.
+
+---
+
+## 4. License audit (verified from primary `LICENSE` files / PyPI)
+
+For a permissive (MIT/BSD) public PyPI package, the optimizer's license is a tier-① constraint.
+
+| Implementation | License (verified) | Class | Verdict for PyTopo3D |
+|---|---|---|---|
+| Svanberg MMA/GCMMA (smoptit.se) | **GPL-3.0** | strong copyleft | ❌ cannot vendor |
+| `GCMMA-MMA-Python` (Deetman) | **GPL-3.0** | strong copyleft | ❌ cannot vendor |
+| `mmapy` (PyPI) | **GPL-3.0** | strong copyleft | ❌ cannot vendor |
+| **NLopt MMA/CCSA** (`src/algs/mma`) | **MIT** — S. G. Johnson's independent reimpl "described in" Svanberg 2002 | permissive | ✅ **clean MMA** |
+| `nlopt` (PyPI wheel) | MIT, or LGPL-2.1 if built with `luksan` | permissive / weak-copyleft | ✅ fine **as a dependency** (no copyleft propagation to your code) |
+| IPOPT / `cyipopt` | **EPL-2.0** (+ MUMPS/HSL linear solver) | weak copyleft | ⚠️ ok as *optional external* dep; heavier |
+| SciPy (`scipy.optimize` SLSQP) | **BSD-3-Clause** | permissive | ✅ clean (but SQP, not MMA) |
+
+**Key finding:** the GPL problem is real but *avoidable*. NLopt's MMA is an MIT reimplementation independent of Svanberg's GPL code (verified from `src/algs/mma/README`: "It is under the same MIT license as the rest of my code in NLopt"). The "academic-only / by-request" lore about Svanberg's code is a courtesy request, not the license — the actual `smoptit.se` distribution is GPLv3, which is the genuine blocker for *vendoring*. Depending on the `nlopt` wheel does not impose copyleft on PyTopo3D's own code.
+
+---
+
+## 5. Scoring against the four criteria
+
+Scale: ●●● strong · ●●○ moderate · ●○○ weak. Criteria: **(1)** elegance/modernity · **(2)** license/dependency cleanliness · **(3)** verification/commercial alignment · **(4)** future-roadmap generality.
+
+| Candidate | (1) Elegance | (2) License | (3) Verified/commercial | (4) Generality | Net |
+|---|:---:|:---:|:---:|:---:|---|
+| OC + continuation/projection (port from `top3d`) | ●●○ | ●●● | ●●○ | ●○○ | **Best for convergence; useless for mass-min** |
+| **MMA via NLopt (MIT)** | ●●○ | ●●● | ●●● | ●●● | **Best overall for mass-min + future constraints** |
+| MMA/GCMMA via Svanberg/Deetman (GPL) | ●●○ | ●○○ | ●●● | ●●● | Ruled out on license |
+| IPOPT via cyipopt (EPL) | ●●● | ●●○ | ●●● | ●●● | Strong alternative; heavier deps |
+| SciPy SLSQP (BSD) | ●●○ | ●●● | ●●○ | ●●○ | Small problems only (dense SQP scaling) |
+| Differentiable/autodiff TO (JAX) | ●●● | ●●● | ●○○ | ●●○ | Modern but unproven here; needs FE-backend rewrite |
+| NN direct design (TOuNN-style) | ●●● | ●●● | ●○○ | ●○○ | Not competitive (Woldseth 2022) |
+
+**Most-used vs most-elegant:** the most-used method (MMA) and the most-elegant *available, proven, license-clean* choice for this codebase coincide once you (a) source MMA from NLopt and (b) discount the flashy NN/autodiff path on the evidence. The only serious rival on pure elegance is **IPOPT** ("use a real NLP solver"), which loses on dependency/license weight (EPL + a MUMPS/HSL linear solver) but is the right documented fallback.
+
+---
+
+## 6. PyTopo3D-specific fit
+
+- **Sensitivities already exist analytically** (`dc`, `dv` in `pytopo3d/core/optimizer.py`). OC, MMA (NLopt), IPOPT, and SLSQP all consume them directly — small, surgical integration. Differentiable/autodiff TO would require rewriting the FE core onto a differentiable backend (JAX/Torch) to obtain a value autodiff provides — sensitivities — that the package **already has**. Low return.
+- **0/1 crispness** is handled by SIMP penalty + (to be added) projection, independent of optimizer choice.
+- **API-freeze timing:** 0.4.0 freezes the API. Adopting a general optimizer interface (objective + list of constraints) in 0.3.0 means the mass-min/stress/multiphysics signature is settled *before* the freeze. MMA-via-NLopt and IPOPT both fit this interface; OC does not.
+- **GPU path:** PyTopo3D's optional CuPy path accelerates the FE/CG solve, which dominates cost. The optimizer update (OC or MMA) is cheap by comparison, so an MMA on CPU (NLopt) does not bottleneck a GPU-accelerated solve.
+
+---
+
+## 7. Recommendation
+
+> **Superseded on sequencing & integration (2026-06-16):** `docs/literature-reviews/0.3.0-implementation-plan.md` is the confirmed plan. It keeps this memo's *optimizer* conclusion (adopt MMA via NLopt) but (a) reverses item 1 — convergence aids are **conditional, coupled to mass minimization**, not shipped first as a standalone change — and (b) adopts NLopt **behind an optimizer-agnostic seam** (physics-as-callback), not as a bare runtime dependency, so the kernel can later be swapped for an owned/commercial engine.
+
+1. **Convergence aids — conditional, coupled to mass-min (not a standalone first step).** Penalty-**continuation** and **gray-scale filter** that Liu & Tovar (2014) document as `top3d` extensions, and/or **robust Heaviside projection** (Wang/Guest/Sigmund lineage), are added only when mass-min or a manufacturability need exercises them. Re-measure the golden master afterward (a model change re-opens the baseline).
+2. **Add Mass Minimization on MMA, sourced from `nlopt` (MIT).** Feed it the existing analytic sensitivities. This also unlocks the beyond-roadmap constrained problems (stress, manufacturability, multiphysics) that the roadmap parks for later — Woldseth et al. note MMA makes "switching the objective and constraint functions … straightforward."
+3. **Document IPOPT (cyipopt, EPL-2.0) as the fallback** for anyone needing a full interior-point NLP solver; keep it an *optional* extra, not a core dependency.
+4. **Do not** vendor GPL MMA, and **do not** pursue NN/autodiff as the optimizer (only consider autodiff later if/when a differentiable backend is wanted for a different reason).
+
+**Net:** "just use MMA" was directionally right, but the decision that survives scrutiny is sharper — *MMA via NLopt's MIT implementation, kept separate from a cheaper convergence-only sub-step, with IPOPT as the named fallback.*
+
+---
+
+## Appendix A: Annotated source list (tiered)
+
+**Tier 1 — core, read in full or abstract-verified:**
+- Svanberg 1987, *The method of moving asymptotes* — `W2062523101`, DOI 10.1002/nme.1620240207 (abstract verified).
+- Svanberg 2002, *GCMMA / conservative convex separable approximations* — `W2153245297`, DOI 10.1137/s1052623499362822 (abstract verified).
+- Liu & Tovar 2014, *An efficient 3D topology optimization code (`top3d`)* — `W2048785994`, DOI 10.1007/s00158-014-1107-x (**full text read**; PyTopo3D's source).
+- Woldseth, Aage, Bærentzen & Sigmund 2022, *On the use of ANNs in topology optimisation* — `W4298156653`, arXiv:2208.02563 (**full text read**).
+- Sigmund 2011, *On the usefulness of non-gradient approaches* — `W2056802356`, DOI 10.1007/s00158-011-0638-7 (**abstract-only**; body paywalled — flagged).
+- Aage et al. 2017, *Giga-voxel computational morphogenesis* — `W2761536263`, DOI 10.1038/nature23911 (abstract/metadata).
+
+**Tier 2 — important context:**
+- Sigmund & Maute 2013, *Topology optimization approaches* (review) — `W2220999736`, DOI 10.1007/s00158-013-0978-6.
+- Andreassen et al. 2011, *88-line* — `W2141377530`. · Ferrari & Sigmund 2020, *new 99-line* — `W3024236378`, DOI 10.1007/s00158-020-02629-w.
+- Chandrasekhar & Suresh 2020, *TOuNN* — `W3106486741`. · Hoyer et al. 2019, *Neural reparameterization* — arXiv:1909.04240.
+- *Density-based TO with the Null Space Optimizer: a tutorial and comparison* 2024 — `W4390610057`, DOI 10.1007/s00158-023-03710-w.
+- JAX-FEM 2023 — `W4379196907`. · AuTO 2021 — `W3140287683`. · Generalized OC 2021 — `W3140833829`.
+
+**Commercial docs (primary):** COMSOL Optimization Module solver list (GCMMA); Altair OptiStruct gradient-method guide (DUAL2/CONLIN); Abaqus/Tosca optimization-task doc (MMA/Svanberg); ANSYS Structural Optimization guide 2025 R1 (SCP-extends-MMA, OC).
+
+**License sources (primary):** smoptit.se; `arjendeetman/GCMMA-MMA-Python` LICENSE; `mmapy` PyPI; `stevengj/nlopt` `COPYING` + `src/algs/mma/README`; `coin-or/Ipopt` & `mechmotum/cyipopt` LICENSE; `scipy` LICENSE.txt.
+
+## Appendix B: Search documentation
+- **Discovery:** OpenAlex REST (works/citations/by-DOI), 4 lenses (seminal, recent, methods, critique) + forward-citation chase from Svanberg-MMA (`cites:W2062523101`). OpenAlex polite pool.
+- **Gotcha logged:** OpenAlex `search=` combined with `sort=cited_by_count:desc` (or with no filter) silently returned globally-top-cited noise; the reliable patterns were `search=`+`filter=…` and `/works/doi:…`.
+- **Verification:** licenses and commercial optimizers were not in OpenAlex; verified by primary-source web fetches (GitHub `LICENSE`, PyPI, vendor docs) via parallel agents, with the load-bearing NLopt-MMA-is-MIT claim re-checked directly against `src/algs/mma/README`.
+
+## Limitations
+- Sigmund 2011 body text is paywalled; only its abstract was verified (thesis is unambiguous there). Several Springer/SMO abstracts are absent from OpenAlex.
+- Altair's CONLIN/DUAL2 internals are proprietary (family disclosed, formulation not). The `nlopt` wheel's exact license depends on its build (MIT vs LGPL with `luksan`); either is dependency-safe for a permissive package, but vendoring/modifying would need the build checked.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytopo3d"
-version = "0.2.2"
+version = "0.3.0"
 description = "3D SIMP Topology Optimization Framework for Python"
 readme = "README.md"
 authors = [

--- a/pytopo3d/core/evaluator.py
+++ b/pytopo3d/core/evaluator.py
@@ -1,0 +1,110 @@
+"""Physics evaluator: compliance and its design sensitivities.
+
+This is the swappable seam (see ``docs/literature-reviews/0.3.0-implementation-plan.md``,
+P3) between the finite-element physics and the optimizer. Given the physical (filtered)
+density field ``xPhys`` it assembles ``K(xPhys)``, solves ``K U = F``, and returns the
+compliance objective together with its sensitivities. Both integration modes call it --
+the framework-owns-loop OC update today, and the solver-owns-loop NLopt MMA backend later
+-- so no optimizer owns the physics and the optimizer kernel stays swappable.
+
+CPU path only. The optimizer keeps its own CuPy GPU branch for now; a GPU evaluator
+follows when the two loops are unified.
+
+The returned ``dv`` is the **clean** volume sensitivity -- it deliberately does NOT carry
+OC's ``+1e-9`` division guard. The OC call site adds that itself, so a future MMA/NLopt
+backend receives the true gradient rather than an OC-specific perturbation.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+import scipy.sparse as sp
+
+from pytopo3d.core.compliance import element_compliance
+
+
+class ComplianceEvaluator:
+    """Assemble, solve, and return ``(c, dc, dv)`` on the CPU.
+
+    Static problem data (element stiffness, the CSR scatter map and its preallocated
+    structure, loads, supports, the density filter, and the obstacle mask) is built once
+    and held. ``evaluate`` is then called per iteration with the current physical density
+    and penalization.
+    """
+
+    def __init__(
+        self,
+        *,
+        KE: np.ndarray,
+        dup2uniq: np.ndarray,
+        K: sp.csr_matrix,
+        freedofs0: np.ndarray,
+        F: np.ndarray,
+        ndof: int,
+        solver_func,
+        edofMat: np.ndarray,
+        shape: Tuple[int, int, int],  # (nely, nelx, nelz) -- y first, per the array layout
+        H: sp.csr_matrix,
+        Hs: np.ndarray,
+        obstacle_mask: np.ndarray,
+        E0: float = 1.0,
+        Emin: float = 1e-9,
+    ) -> None:
+        self.KE = KE
+        self.dup2uniq = dup2uniq
+        self.K = K
+        self.freedofs0 = freedofs0
+        self.F = F
+        self.ndof = ndof
+        self.solver_func = solver_func
+        self.edofMat = edofMat
+        self.shape = shape
+        self.H = H
+        self.Hs = Hs
+        self.obstacle_mask = obstacle_mask
+        self.E0 = E0
+        self.Emin = Emin
+
+    def evaluate(
+        self, xPhys: np.ndarray, penal: float
+    ) -> Tuple[float, np.ndarray, np.ndarray]:
+        """Return ``(c, dc, dv)`` for physical density ``xPhys`` at penalization ``penal``.
+
+        ``dc`` and ``dv`` are filtered (the density-filter chain rule) and zeroed on
+        obstacle elements. ``dv`` is the clean volume sensitivity (no OC ``+1e-9`` guard).
+        """
+        nely, nelx, nelz = self.shape
+        E0, Emin = self.E0, self.Emin
+
+        # Assemble the global stiffness, reusing the preallocated CSR structure.
+        stiff = Emin + (xPhys.ravel(order="F") ** penal) * (E0 - Emin)
+        elem_vals = np.kron(stiff, self.KE.ravel())
+        self.K.data[:] = 0.0
+        np.add.at(self.K.data, self.dup2uniq, elem_vals)
+
+        # Solve on the free DOFs.
+        Kff = self.K[self.freedofs0, :][:, self.freedofs0]
+        Uf = self.solver_func(Kff, self.F[self.freedofs0])
+        U = np.zeros(self.ndof)
+        U[self.freedofs0] = Uf
+
+        # Compliance and raw (unfiltered) sensitivities.
+        ce = element_compliance(U, self.edofMat, self.KE).reshape(
+            nely, nelx, nelz, order="F"
+        )
+        c = ((Emin + xPhys ** penal * (E0 - Emin)) * ce).sum()
+        dc = -penal * (E0 - Emin) * xPhys ** (penal - 1) * ce
+        dv = np.ones_like(xPhys)
+
+        # Density-filter chain rule, then zero obstacle elements.
+        dc = (self.H * (dc.ravel(order="F") / self.Hs)).reshape(
+            (nely, nelx, nelz), order="F"
+        )
+        dv = (self.H * (dv.ravel(order="F") / self.Hs)).reshape(
+            (nely, nelx, nelz), order="F"
+        )
+        dc[self.obstacle_mask] = 0.0
+        dv[self.obstacle_mask] = 0.0
+        return c, dc, dv

--- a/pytopo3d/core/evaluator.py
+++ b/pytopo3d/core/evaluator.py
@@ -10,9 +10,12 @@ the framework-owns-loop OC update today, and the solver-owns-loop NLopt MMA back
 CPU path only. The optimizer keeps its own CuPy GPU branch for now; a GPU evaluator
 follows when the two loops are unified.
 
-The returned ``dv`` is the **clean** volume sensitivity -- it deliberately does NOT carry
-OC's ``+1e-9`` division guard. The OC call site adds that itself, so a future MMA/NLopt
-backend receives the true gradient rather than an OC-specific perturbation.
+The returned ``dv`` omits OC's ``+1e-9`` division guard (the OC call site adds that itself).
+NOTE: with obstacles it is *not* yet the exact volume-constraint gradient -- obstacle cells
+are zeroed *after* the filter rather than excluded before it, so their sensitivity leaks into
+neighbours. This is carried over verbatim from the original loop and is fine for the OC
+bisection, but a future MMA/NLopt backend should exclude obstacle cells before the filter
+chain rule for obstacle problems.
 """
 
 from __future__ import annotations

--- a/pytopo3d/core/optimizer.py
+++ b/pytopo3d/core/optimizer.py
@@ -20,6 +20,7 @@ import scipy.sparse as sp
 import matplotlib.pyplot as plt
 
 from pytopo3d.core.compliance import element_compliance
+from pytopo3d.core.evaluator import ComplianceEvaluator
 from pytopo3d.utils.assembly import build_edof, build_force_vector, build_supports
 from pytopo3d.utils.filter import HAS_CUPY, apply_filter, build_filter
 from pytopo3d.utils.logger import get_logger
@@ -145,6 +146,25 @@ def top3d(
         )
     else:
         K = sp.csr_matrix((np.zeros(len(i_unique)), (i_unique, j_unique)), shape=(ndof, ndof))
+        # Physics evaluator (the swappable seam): assembles K(xPhys), solves, and returns
+        # (c, dc, dv). The CPU loop below calls it; the GPU branch keeps its own inline
+        # physics for now. Returns the clean dv (no OC +1e-9 guard) — added at the OC call.
+        cpu_evaluator = ComplianceEvaluator(
+            KE=KE,
+            dup2uniq=dup2uniq,
+            K=K,
+            freedofs0=freedofs0,
+            F=F,
+            ndof=ndof,
+            solver_func=solver_func,
+            edofMat=edofMat,
+            shape=(nely, nelx, nelz),
+            H=H,
+            Hs=Hs,
+            obstacle_mask=obstacle_mask,
+            E0=E0,
+            Emin=Emin,
+        )
 
     # ─────────────────────── main loop
     loop, change, c_prev = 0, 1.0, np.inf
@@ -214,26 +234,8 @@ def top3d(
 
         # ================================================= CPU
         else:
-            stiff = Emin + (xPhys.ravel(order="F") ** penal) * (E0 - Emin)
-            elem_vals = np.kron(stiff, KE.ravel())
-            K.data[:] = 0.0
-            np.add.at(K.data, dup2uniq, elem_vals)
-
-            Kff = K[freedofs0, :][:, freedofs0]
-            Uf = solver_func(Kff, F[freedofs0])
-            U = np.zeros(ndof)
-            U[freedofs0] = Uf
-
-            ce_flat = element_compliance(U, edofMat, KE)
-            ce = ce_flat.reshape(nely, nelx, nelz, order="F")
-            c = ((Emin + xPhys ** penal * (E0 - Emin)) * ce).sum()
-
-            dc = -penal * (E0 - Emin) * xPhys ** (penal - 1) * ce
-            dv = np.ones_like(xPhys)
-            dc = (H * (dc.ravel(order="F") / Hs)).reshape((nely, nelx, nelz), order="F")
-            dv = (H * (dv.ravel(order="F") / Hs)).reshape((nely, nelx, nelz), order="F")
-            dc[obstacle_mask] = dv[obstacle_mask] = 0.0
-            dv += 1e-9
+            c, dc, dv = cpu_evaluator.evaluate(xPhys, penal)
+            dv += 1e-9  # OC divides by dv (oc_update); MMA/NLopt would use the clean dv
 
             xnew, change = optimality_criteria_update(
                 x,

--- a/pytopo3d/utils/assembly.py
+++ b/pytopo3d/utils/assembly.py
@@ -9,6 +9,8 @@ from typing import Optional, Set, Tuple
 
 import numpy as np
 
+from pytopo3d.utils.axis_convention import warn_force_xy_change_once
+
 
 def build_force_vector(
     nelx: int,
@@ -73,6 +75,11 @@ def build_force_vector(
                 f"force_field has shape {force_field.shape}, "
                 f"but expected {expected_shape}"
             )
+
+        # The x/y force-direction transpose was fixed in 0.3.0; warn once if this load
+        # carries Fx or Fy components (whose behaviour changed). Fz-only loads are unaffected.
+        if np.any(force_field[..., 0]) or np.any(force_field[..., 1]):
+            warn_force_xy_change_once()
 
         # Iterate through each element and distribute its force to its 8 nodes
         for elz in range(nelz):
@@ -283,46 +290,49 @@ def build_edof(
         3 * edofVec_node_ids - 2
     )  # 3*nid - 2 -> x-dof ; 3*nid - 1 -> y-dof ; 3*nid -> z-dof
 
-    # Define the offsets to get the 24 DOFs of an H8 element relative to the first DOF
-    # Node order (local): 0,1,2,3 (bottom face z=0), 4,5,6,7 (top face z=1)
-    # Local node coords (y, x, z):
+    # Define the offsets to get the 24 DOFs of an H8 element relative to the first DOF.
+    # Node order (local): 0,1,2,3 (bottom face z=0), 4,5,6,7 (top face z=1) -- matches the
+    # lk_H8 element's local node ordering, so the element's first local axis aligns with the
+    # grid's x (nelx) axis. Local node coords (x, y, z):
     # 0:(0,0,0), 1:(1,0,0), 2:(1,1,0), 3:(0,1,0)
     # 4:(0,0,1), 5:(1,0,1), 6:(1,1,1), 7:(0,1,1)
-    # DOFs follow node order: [node0_x, node0_y, node0_z, node1_x, ..., node7_z]
-    # Offsets calculated relative to edofVec (node0_x DOF)
+    # DOFs follow node order: [node0_x, node0_y, node0_z, node1_x, ..., node7_z].
+    # The +x neighbour is one node over in x (offset 3*(nely+1)); the +y neighbour is the
+    # next node id (offset 3*1). NOTE: before the 0.3.0 fix nodes 1<->3 (and 5<->7) used the
+    # opposite offsets, which transposed the element's x and y axes -- a regression from
+    # commit 75174dd that made an "Fx" load act along y. See tests/test_force_direction.py.
     dof_offsets = np.array(
         [
             0,
             1,
-            2,  # Node 0 (iy=0, ix=0, iz=0)
-            3 * 1 + 0,
-            3 * 1 + 1,
-            3 * 1 + 2,  # Node 1 (iy=1, ix=0, iz=0) Offset=3*dy=3
+            2,  # Node 0 (ix=0, iy=0, iz=0)
+            3 * (nely + 1) + 0,
+            3 * (nely + 1) + 1,
+            3 * (nely + 1) + 2,  # Node 1 (ix=1, iy=0, iz=0) Offset=3*dx*(nely+1)
             3 * (nely + 1 + 1) + 0,
             3 * (nely + 1 + 1) + 1,
             3 * (nely + 1 + 1)
-            + 2,  # Node 2 (iy=1, ix=1, iz=0) Offset=3*(dx*(nely+1)+dy) = 3*(nely+1+1)
-            3 * (nely + 1) + 0,
-            3 * (nely + 1) + 1,
-            3 * (nely + 1)
-            + 2,  # Node 3 (iy=0, ix=1, iz=0) Offset=3*dx*(nely+1)=3*(nely+1)
+            + 2,  # Node 2 (ix=1, iy=1, iz=0) Offset=3*(dx*(nely+1)+dy) = 3*(nely+1+1)
+            3 * 1 + 0,
+            3 * 1 + 1,
+            3 * 1 + 2,  # Node 3 (ix=0, iy=1, iz=0) Offset=3*dy=3
             3 * (nelx + 1) * (nely + 1) + 0,
             3 * (nelx + 1) * (nely + 1) + 1,
             3 * (nelx + 1) * (nely + 1)
-            + 2,  # Node 4 (iy=0, ix=0, iz=1) Offset=3*dz*(nelx+1)*(nely+1)
-            3 * (nelx + 1) * (nely + 1) + 3 * 1 + 0,
-            3 * (nelx + 1) * (nely + 1) + 3 * 1 + 1,
-            3 * (nelx + 1) * (nely + 1) + 3 * 1 + 2,  # Node 5 (iy=1, ix=0, iz=1)
+            + 2,  # Node 4 (ix=0, iy=0, iz=1) Offset=3*dz*(nelx+1)*(nely+1)
+            3 * (nelx + 1) * (nely + 1) + 3 * (nely + 1) + 0,
+            3 * (nelx + 1) * (nely + 1) + 3 * (nely + 1) + 1,
+            3 * (nelx + 1) * (nely + 1) + 3 * (nely + 1) + 2,  # Node 5 (ix=1, iy=0, iz=1)
             3 * (nelx + 1) * (nely + 1) + 3 * (nely + 1 + 1) + 0,
             3 * (nelx + 1) * (nely + 1) + 3 * (nely + 1 + 1) + 1,
             3 * (nelx + 1) * (nely + 1)
             + 3 * (nely + 1 + 1)
-            + 2,  # Node 6 (iy=1, ix=1, iz=1)
-            3 * (nelx + 1) * (nely + 1) + 3 * (nely + 1) + 0,
-            3 * (nelx + 1) * (nely + 1) + 3 * (nely + 1) + 1,
+            + 2,  # Node 6 (ix=1, iy=1, iz=1)
+            3 * (nelx + 1) * (nely + 1) + 3 * 1 + 0,
+            3 * (nelx + 1) * (nely + 1) + 3 * 1 + 1,
             3 * (nelx + 1) * (nely + 1)
-            + 3 * (nely + 1)
-            + 2,  # Node 7 (iy=0, ix=1, iz=1)
+            + 3 * 1
+            + 2,  # Node 7 (ix=0, iy=1, iz=1)
         ],
         dtype=int,
     )
@@ -331,7 +341,6 @@ def build_edof(
     edofMat = edofVec[:, np.newaxis] + dof_offsets[np.newaxis, :]
 
     # Prepare iK, jK indices (1-based) for COO sparse matrix format
-    nele = nelx * nely * nelz
     iK = np.kron(edofMat, np.ones((1, 24), dtype=int)).ravel()
     jK = np.kron(edofMat, np.ones((24, 1), dtype=int)).ravel()
 

--- a/pytopo3d/utils/axis_convention.py
+++ b/pytopo3d/utils/axis_convention.py
@@ -1,7 +1,8 @@
-"""One-time runtime notice for the 0.2.0 STL axis-convention change.
+"""One-time runtime notices for axis-convention changes.
 
-Transitional: emitted once per session the first time an STL is imported or exported,
-so users upgrading from 0.1.x notice that STL results now differ. Remove in 0.3.0.
+Transitional notices, emitted once per session so users upgrading notice that results
+differ: (1) the 0.2.0 STL x/y axis change (remove in 0.3.0), and (2) the 0.3.0 `force_field`
+Fx/Fy transpose fix (remove in 0.4.0).
 """
 
 import warnings
@@ -24,3 +25,22 @@ def warn_stl_axis_change_once() -> None:
         # stacklevel=3: warn -> warn_stl_axis_change_once -> public STL fn -> user code,
         # so 3 points the warning at the caller of stl_to_design_space / voxel_to_stl.
         warnings.warn(_MESSAGE, UserWarning, stacklevel=3)
+
+
+_FORCE_WARNED = False
+
+_FORCE_MESSAGE = (
+    "PyTopo3D 0.3.0 fixed an x/y transpose in force_field: components Fx (index 0) and "
+    "Fy (index 1) now act along the correct axes (they were swapped before). force_field "
+    "loads with distinct Fx and Fy change; -z-only and x<->y-symmetric loads are unchanged. "
+    "Pin the previous release to reproduce the old behavior. See CHANGELOG.md. "
+    "(Shown once; removed in 0.4.0.)"
+)
+
+
+def warn_force_xy_change_once() -> None:
+    """Emit the force_field x/y fix notice at most once per session (only for Fx/Fy loads)."""
+    global _FORCE_WARNED
+    if not _FORCE_WARNED:
+        _FORCE_WARNED = True
+        warnings.warn(_FORCE_MESSAGE, UserWarning, stacklevel=3)

--- a/tests/test_force_direction.py
+++ b/tests/test_force_direction.py
@@ -1,0 +1,100 @@
+"""Locks the public (x, y, z) force-direction convention.
+
+`force_field` component 0 ("Fx") must act along the physical x (= `nelx`) axis, component 1
+along y, component 2 along z. A rewrite of `build_edof` in commit 75174dd silently swapped
+the element's first two local axes, so an "Fx" load acted along the `nely` (y) axis instead
+of x -- a regression invisible to the golden master (default load is -z, unaffected) and to
+the STL-orientation tests (which check geometry positions, not force directions).
+
+Test: on a beam long along x, an axial Fx load is stiff (small compliance) while transverse
+Fy / Fz loads bend the beam (much larger compliance). If Fx is NOT the smallest, x and y are
+transposed.
+"""
+
+import numpy as np
+import scipy.sparse as sp
+from scipy.sparse.linalg import spsolve
+
+from pytopo3d.utils.assembly import build_edof, build_force_vector, build_supports
+from pytopo3d.utils.stiffness import lk_H8
+
+
+def _beam_compliances():
+    """Solid beam long along x (16x4x4), fixed at x=0; unit load per force component."""
+    nelx, nely, nelz = 16, 4, 4
+    ndof = 3 * (nelx + 1) * (nely + 1) * (nelz + 1)
+    KE = lk_H8(0.3)
+    edofMat, _, _ = build_edof(nelx, nely, nelz)
+    d0 = edofMat - 1
+    rows = np.repeat(d0, 24, axis=1).ravel()
+    cols = np.tile(d0, (1, 24)).ravel()
+    vals = np.tile(KE.ravel(), d0.shape[0])
+    K = sp.coo_matrix((vals, (rows, cols)), shape=(ndof, ndof)).tocsr()
+    free, _ = build_supports(nelx, nely, nelz, ndof, None)  # default: fix the x=0 face
+    Kff = K[free][:, free]
+
+    compliances = []
+    for comp in range(3):
+        ff = np.zeros((nely, nelx, nelz, 3))
+        ff[:, nelx - 1, :, comp] = -1.0  # unit load on the far-x face, this component
+        F = build_force_vector(nelx, nely, nelz, ndof, ff)
+        u = np.zeros(ndof)
+        u[free] = spsolve(Kff, F[free])
+        compliances.append(float(F @ u))
+    return compliances  # [Fx, Fy, Fz]
+
+
+def test_fx_is_axial_fy_fz_are_transverse():
+    cx, cy, cz = _beam_compliances()
+    assert cx < 0.2 * cy and cx < 0.2 * cz, (
+        f"force_field component 0 (Fx) must act along x (axial, stiff) on an x-long beam, "
+        f"but compliances are Fx={cx:.1f}, Fy={cy:.1f}, Fz={cz:.1f}. If Fx is one of the "
+        f"large (transverse) values, the x<->y force convention is transposed (regression)."
+    )
+
+
+def test_force_xy_notice_fires_once_for_fx_load():
+    """An Fx/Fy force_field triggers the one-time 0.3.0 transpose-fix notice, once only."""
+    import warnings
+
+    import pytest
+
+    import pytopo3d.utils.axis_convention as ac
+
+    nelx, nely, nelz = 4, 3, 2
+    ndof = 3 * (nelx + 1) * (nely + 1) * (nelz + 1)
+    ff = np.zeros((nely, nelx, nelz, 3))
+    ff[0, nelx - 1, 0, 0] = -1.0  # an Fx (component 0) load
+
+    original = ac._FORCE_WARNED
+    ac._FORCE_WARNED = False
+    try:
+        with pytest.warns(UserWarning, match="x/y transpose"):
+            build_force_vector(nelx, nely, nelz, ndof, ff)
+        # A second force_field call must NOT warn again (once per session).
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            build_force_vector(nelx, nely, nelz, ndof, ff)
+    finally:
+        ac._FORCE_WARNED = original
+
+
+def test_force_z_only_does_not_warn():
+    """An Fz-only force_field is unaffected by the x/y fix, so it must stay silent."""
+    import warnings
+
+    import pytopo3d.utils.axis_convention as ac
+
+    nelx, nely, nelz = 4, 3, 2
+    ndof = 3 * (nelx + 1) * (nely + 1) * (nelz + 1)
+    ff = np.zeros((nely, nelx, nelz, 3))
+    ff[0, nelx - 1, 0, 2] = -1.0  # Fz only
+
+    original = ac._FORCE_WARNED
+    ac._FORCE_WARNED = False
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any warning becomes an error
+            build_force_vector(nelx, nely, nelz, ndof, ff)  # must not warn
+    finally:
+        ac._FORCE_WARNED = original

--- a/tests/test_gradient_check.py
+++ b/tests/test_gradient_check.py
@@ -1,0 +1,80 @@
+"""R1 -- finite-difference gradient check for the compliance evaluator.
+
+The foundational test for a gradient-based optimizer (plan P4.1.1): the analytic
+sensitivity ``dc`` that ``ComplianceEvaluator`` returns must equal the gradient of the
+compliance it returns, verified against central finite differences of the *full*
+design -> density-filter -> physics chain. This catches the sign / scaling / missing
+filter-chain-rule errors that the higher-level feasibility and monotonicity checks would
+silently pass over (a wrong gradient still converges to a wrong-but-feasible point).
+"""
+
+import numpy as np
+import scipy.sparse as sp
+
+from pytopo3d.core.evaluator import ComplianceEvaluator
+from pytopo3d.core.optimizer import _make_scatter_map
+from pytopo3d.utils.assembly import build_edof, build_force_vector, build_supports
+from pytopo3d.utils.filter import build_filter
+from pytopo3d.utils.solver import get_solver
+from pytopo3d.utils.stiffness import lk_H8
+
+
+def _build(nelx, nely, nelz, rmin):
+    """Assemble the same static context the optimizer builds, with no obstacles."""
+    nu = 0.3
+    ndof = 3 * (nelx + 1) * (nely + 1) * (nelz + 1)
+    F = build_force_vector(nelx, nely, nelz, ndof, None)
+    freedofs0, _ = build_supports(nelx, nely, nelz, ndof, None)
+    KE = lk_H8(nu)
+    edofMat, iK, jK = build_edof(nelx, nely, nelz)
+    i_u, j_u, dup2uniq = _make_scatter_map(iK - 1, jK - 1, ndof)
+    K = sp.csr_matrix((np.zeros(len(i_u)), (i_u, j_u)), shape=(ndof, ndof))
+    H, Hs = build_filter(nelx, nely, nelz, rmin)
+    shape = (nely, nelx, nelz)
+    ev = ComplianceEvaluator(
+        KE=KE, dup2uniq=dup2uniq, K=K, freedofs0=freedofs0, F=F, ndof=ndof,
+        solver_func=get_solver(False)[0], edofMat=edofMat, shape=shape,
+        H=H, Hs=Hs, obstacle_mask=np.zeros(shape, dtype=bool),
+    )
+    return ev, H, Hs, shape
+
+
+def _max_rel_error(seed=0, h=1e-6, n_samples=10):
+    nelx, nely, nelz, rmin, penal = 4, 3, 2, 1.5, 3.0
+    ev, H, Hs, shape = _build(nelx, nely, nelz, rmin)
+
+    # Density filter, matching optimizer.py exactly: xPhys = (H @ x) / Hs.
+    def xphys(xd):
+        return (H * xd.ravel(order="F") / Hs).reshape(shape, order="F")
+
+    def compliance(xd):
+        return ev.evaluate(xphys(xd), penal)[0]
+
+    rng = np.random.default_rng(seed)
+    x = rng.uniform(0.3, 0.7, size=shape)          # interior, so x +/- h stays in (0, 1)
+    _, dc, _ = ev.evaluate(xphys(x), penal)        # analytic d(compliance)/d(x_design)
+
+    worst = 0.0
+    for k in rng.choice(x.size, size=n_samples, replace=False):
+        idx = np.unravel_index(k, x.shape)
+        xp, xm = x.copy(), x.copy()
+        xp[idx] += h
+        xm[idx] -= h
+        fd = (compliance(xp) - compliance(xm)) / (2 * h)        # central difference
+        rel = abs(fd - dc[idx]) / max(abs(dc[idx]), 1e-30)
+        worst = max(worst, rel)
+    return worst
+
+
+def test_compliance_gradient_matches_finite_difference():
+    # Tolerance derived from the measured central-difference error window (plan R3):
+    # the best h sits where truncation O(h^2) and round-off O(eps/h) balance; well within
+    # 1e-4 relative here. A sign error makes fd and dc differ by ~2x -> ~1.0 relative, so
+    # this gate is sharp (mutation: flip the dc sign and it fails by orders of magnitude).
+    assert _max_rel_error(h=1e-6) < 1e-4
+
+
+def test_gradient_check_is_consistent_across_h():
+    # The agreement is not a fluke of one step size: central differences converge.
+    assert _max_rel_error(h=1e-5) < 1e-4
+    assert _max_rel_error(h=1e-6) < 1e-4

--- a/tests/test_physics_anchor.py
+++ b/tests/test_physics_anchor.py
@@ -1,0 +1,117 @@
+"""R2 -- closed-form absolute anchor for the physics (plan P4.1.2).
+
+The relative checks (gradient consistency in R1, cross-solver agreement later) are blind
+to a *shared/systematic* error: a globally mis-scaled stiffness keeps compliance and its
+gradient mutually consistent, so R1 still passes. This test pins the physics to analytic
+ground truth.
+
+Axis convention: after the 0.3.0 fix to `build_edof`, the element's local axes align with
+the grid axes -- a node at grid index ``(ix, iy, iz)`` sits at physical ``(x, y, z) =
+(ix, iy, iz)`` and its DOFs ``3*nid + {0,1,2}`` are displacements along ``(x, y, z)``.
+(`test_force_direction.py` locks the user-facing half of this; before the fix x and y were
+transposed.)
+
+Two anchors:
+  * energy patch test -- imposes the analytic uniaxial-stress field and checks the strain
+    energy ``U = 1/2 * V * sigma:eps`` exactly. Anchors ``lk_H8`` + assembly; no solve.
+  * uniaxial bar -- runs the full ``ComplianceEvaluator`` (assemble -> solve -> compliance)
+    on a solid Nx1x1 bar (long along x) under uniaxial tension with symmetry (roller) BCs,
+    a constant-strain patch the trilinear hex represents exactly. Closed form:
+    ``C = P^2 L /(A E) = N``.
+"""
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+from pytopo3d.core.evaluator import ComplianceEvaluator
+from pytopo3d.core.optimizer import _make_scatter_map
+from pytopo3d.utils.assembly import build_edof
+from pytopo3d.utils.filter import build_filter
+from pytopo3d.utils.solver import get_solver
+from pytopo3d.utils.stiffness import lk_H8
+
+NU = 0.3
+
+
+def _assemble_solid_K(nelx, nely, nelz):
+    """Assemble the global stiffness of the fully-solid grid (density == 1)."""
+    ndof = 3 * (nelx + 1) * (nely + 1) * (nelz + 1)
+    KE = lk_H8(NU)
+    _, iK, jK = build_edof(nelx, nely, nelz)
+    i_u, j_u, dup2uniq = _make_scatter_map(iK - 1, jK - 1, ndof)
+    K = sp.csr_matrix((np.zeros(len(i_u)), (i_u, j_u)), shape=(ndof, ndof))
+    np.add.at(K.data, dup2uniq, np.kron(np.ones(nelx * nely * nelz), KE.ravel()))
+    return K, ndof
+
+
+def test_single_element_energy_patch():
+    """A uniaxial-stress field on one solid unit element has the exact analytic energy.
+
+    eps = (1, -nu, -nu) gives sigma = (1, 0, 0); energy density 1/2*sigma:eps = 1/2 over a
+    unit volume, so U = 1/2 exactly (a constant-strain patch test). Physical axes = grid axes.
+    """
+    K, ndof = _assemble_solid_K(1, 1, 1)
+    Kd = K.toarray()
+
+    def grid(nid):  # nid = iy + ix*2 + iz*4  ->  (ix, iy, iz)
+        return ((nid // 2) % 2, nid % 2, nid // 4)
+
+    u = np.zeros(ndof)
+    for nid in range(8):
+        ix, iy, iz = grid(nid)
+        u[3 * nid:3 * nid + 3] = [1.0 * ix, -NU * iy, -NU * iz]  # physical (x, y, z) = (ix, iy, iz)
+
+    energy = 0.5 * u @ Kd @ u
+    assert abs(energy - 0.5) <= 1e-12, f"strain energy {energy} != closed-form 0.5"
+
+
+def _uniaxial_bar_evaluator(N):
+    """Solid Nx1x1 bar along x, symmetry BCs, unit axial load P=1.
+
+    A = 1 (one element across each lateral axis), L = N, E = 1 -> C = N exactly.
+    """
+    nelx, nely, nelz = N, 1, 1
+    ndof = 3 * (nelx + 1) * (nely + 1) * (nelz + 1)
+    KE = lk_H8(NU)
+    edofMat, iK, jK = build_edof(nelx, nely, nelz)
+    i_u, j_u, dup2uniq = _make_scatter_map(iK - 1, jK - 1, ndof)
+    K = sp.csr_matrix((np.zeros(len(i_u)), (i_u, j_u)), shape=(ndof, ndof))
+    H, Hs = build_filter(nelx, nely, nelz, 1.5)
+
+    def nid(ix, iy, iz):
+        return iy + ix * (nely + 1) + iz * (nelx + 1) * (nely + 1)
+
+    fixed = set()
+    for iy in range(nely + 1):
+        for iz in range(nelz + 1):
+            fixed.add(3 * nid(0, iy, iz) + 0)        # x=0 face: fix u_x (DOF 0)
+    for ix in range(nelx + 1):
+        for iz in range(nelz + 1):
+            fixed.add(3 * nid(ix, 0, iz) + 1)        # y=0 face: fix u_y (DOF 1)
+    for ix in range(nelx + 1):
+        for iy in range(nely + 1):
+            fixed.add(3 * nid(ix, iy, 0) + 2)        # z=0 face: fix u_z (DOF 2)
+    freedofs0 = np.setdiff1d(np.arange(ndof), np.array(sorted(fixed)))
+
+    F = np.zeros(ndof)
+    n_load = (nely + 1) * (nelz + 1)                 # nodes on the loaded end face (x = L)
+    for iy in range(nely + 1):
+        for iz in range(nelz + 1):
+            F[3 * nid(nelx, iy, iz) + 0] = 1.0 / n_load   # total +x force P = 1, consistent split
+
+    ev = ComplianceEvaluator(
+        KE=KE, dup2uniq=dup2uniq, K=K, freedofs0=freedofs0, F=F, ndof=ndof,
+        solver_func=get_solver(False)[0], edofMat=edofMat, shape=(nely, nelx, nelz),
+        H=H, Hs=Hs, obstacle_mask=np.zeros((nely, nelx, nelz), dtype=bool),
+    )
+    return ev, (nely, nelx, nelz)
+
+
+@pytest.mark.parametrize("N", [1, 2, 4])
+def test_uniaxial_bar_compliance_matches_closed_form(N):
+    ev, shape = _uniaxial_bar_evaluator(N)
+    c, _, _ = ev.evaluate(np.ones(shape), penal=3.0)   # solid: x**penal = 1 for any penal
+    assert abs(c - N) <= 1e-9 * N, (
+        f"compliance {c} != closed-form {N} for an {N}-element uniaxial bar"
+    )


### PR DESCRIPTION
## Summary

Two pieces of 0.3.0 foundation work, with a correctness fix as the headline.

### 1. Fix a `force_field` x/y transpose (breaking, but narrow)

`force_field` components `Fx` and `Fy` were swapped: a user-supplied `Fx` acted along the **y** (`nely`) axis and `Fy` along **x**. The root cause is a `build_edof` rewrite — the same change that added custom `force_field` support and moved the default load from `-y` to `-z` — which silently swapped the H8 element's first two local axes.

Because the new default load is `-z` (unaffected by an x↔y swap), every shipped cantilever example and the golden master kept working, so the regression stayed hidden. It only affects `force_field` loads carrying **distinct** `Fx` vs `Fy`.

**Evidence.** On a beam long in x, `Fx` should be axial (stiff) while `Fy`/`Fz` bend it (much softer). Before the fix, `Fy` was the stiff one — i.e. `Fy` acted along x. The fix restores the correct local-node ordering in `build_edof` so the element's first axis aligns with the grid's x (`nelx`).

**Impact.** Breaking only for `force_field` loads with both x and y components. The default load, `-z`-only loads, supports, obstacle/geometry positions, and the golden-master result are unchanged (max abs difference ~4e-13). The README `force_field` cantilever recipe now behaves as documented. A one-time notice fires for affected loads; pin the previous release to reproduce the old behaviour.

### 2. Extract a `ComplianceEvaluator` seam (behaviour-preserving)

Pull the per-iteration FE physics (assemble `K(xPhys)`, solve, compliance, sensitivities) out of the optimizer's CPU loop into a reusable evaluator, so a future MMA optimizer backend can call the same physics. `top3d()` output is byte-identical (`array_equal`, max diff 0.0).

## Tests

| Test | What it locks |
|---|---|
| `test_force_direction.py` | The public `(x, y, z)` force convention (`Fx` axial on an x-long beam) — mutation-verified red→green; plus the one-time notice |
| `test_gradient_check.py` | Finite-difference check that the analytic sensitivity is the true gradient |
| `test_physics_anchor.py` | Closed-form absolute anchor: single-element energy patch `U = 1/2`, uniaxial bar `C = N` |

Full CPU suite green.

## Roadmap

0.3.0 becomes the force-direction-fix release (mirroring 0.2.0 = the STL coordinate fix); Core Functionality & Interface (mass minimization, GUI) moves to 0.4.0. Design notes for the 0.3.0 optimizer decision (adopt MMA via NLopt) are under `docs/literature-reviews/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
